### PR TITLE
Updated Contributor Agreement.adoc

### DIFF
--- a/content/community/contributing-code/Contributor Agreement.adoc
+++ b/content/community/contributing-code/Contributor Agreement.adoc
@@ -6,10 +6,7 @@ Title: Contributor Agreement
 == Where can I find the Contributor Agreement?
 
 You can find the contributor agreement
-http://suitecrm.com/git/suitecrmcontributorlicenseagreement.pdf[here].
-
-Please read, print, sign, scan and email the contributor agreement to
-the address outlined in the document.
+https://www.clahub.com/agreements/salesagility/SuiteCRM[here].
 
 == What is the Contributor Agreement?
 
@@ -30,10 +27,6 @@ project are against Contributor and not Project.
 requests and contributions in relation to the SuiteCRM project.
 
 == What next?
-
-Once you have signed, scanned and emailed the contributor agreement to
-the SuiteCRM team, we will consider your pull
-request/development/contribution for inclusion in the SuiteCRM project.
 
 You will be notified by email if your pull request/contribution is
 accepted and included in the SuiteCRM project.


### PR DESCRIPTION
Removed a dead link to the old contributors license agreement and replaced it with clahub. Also removed details regarding the old agreement link that are no longer relevant.