### PR TITLE
Fix link to Compatibility Matrix

### DIFF
--- a/content/admin/Installation Guide/3.Upgrading.adoc
+++ b/content/admin/Installation Guide/3.Upgrading.adoc
@@ -18,7 +18,7 @@ production system.
 SuiteCRM runs on a variety of Operating Systems, Web servers, databases
 and PHP versions. It supports many browsers.
 
-Check the link:Compatibility_Matrix[Compatibility Matrix] for complete
+Check the link:/admin/5.compatibility-matrix[Compatibility Matrix] for complete
 information on compatible versions.
 
 [discrete]


### PR DESCRIPTION
As per title, currently the link to [compatibility matrix](https://docs.suitecrm.com/admin/5.compatibility-matrix/) present [here](https://docs.suitecrm.com/admin/installation-guide/3.upgrading) is broken, this fixes it. I chose to use an absolute link starting from `/admin` instead of `../..`  as it seemed better. If other options are more desirable I'll be happy to follow them