### PR TITLE
Update local-setup.adoc

### DIFF
--- a/content/community/contributing-to-docs/local-setup.adoc
+++ b/content/community/contributing-to-docs/local-setup.adoc
@@ -79,8 +79,8 @@ Your contribution can be a new site feature coded in Golang.
 
 == Useful links
 
-https://git-scm.com/book/en/v2/Getting-Started-Installing-Git:[Installing Git^]
+https://git-scm.com/book/en/v2/Getting-Started-Installing-Git[Installing Git^]
 
-https://gohugo.io/getting-started/installing/:[Installing Hugo^]
+https://gohugo.io/getting-started/installing/[Installing Hugo^]
 
-https://asciidoctor.org/docs/install-toolchain/:[Installing Asciidoctor^]
+https://asciidoctor.org/docs/install-toolchain/[Installing Asciidoctor^]


### PR DESCRIPTION
Removed the colon at the end of the URL in the "Useful links" section. With the colon in place we get 404 errors...