### PR TITLE
json api error object, error messages, translation for exceptions, translations for texts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ node_modules/
 
 # macOS
 .DS_Store
+
+
+/nbproject/

--- a/content/developer/API/JSON API Error Object.adoc
+++ b/content/developer/API/JSON API Error Object.adoc
@@ -1,0 +1,60 @@
+---
+Title: JSON API Error Object
+---
+
+== JsonApiErrorObject class
+
+Implementation of JSON API Error Object Specification. 
+See more: http://jsonapi.org/format/#error-objects[^]
+
+== Usage
+
+[source,php]
+--
+
+// creating a new Error Object:
+$error = new JsonApiErrorObject();
+
+// set some known data about the error:
+$error->setTitle(new LangText('LBL_ERROR_LABEL_TITLE'));
+$error->setDetail(new LangText('LBL_ERROR_LABEL_DETAIL'));
+$error->setCode(ERROR_CODE);
+// etc.. see more in source and phpDoc
+
+// creating new Error Object with known data directly in constructor, all parameters are optional:
+$error = new JsonApiErrorObject(
+    // title: a short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem, except for purposes of localization.
+    new LangText('LBL_ERROR_LABEL_TITLE'),      
+    // detail: a human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.
+    new LangText('LBL_ERROR_LABEL_DETAIL'),     
+    // id: a unique identifier for this particular occurrence of the problem.
+    ERROR_ID,                                   
+    // code: an application-specific error code, expressed as a string value.
+    ERROR_CODE,                                 
+    // status: the HTTP status code applicable to this problem, expressed as a string value.
+    STATUS,                                     
+    // links: a links object
+    ['about' => 'Descrioption about the problem'],          
+    // source: an object containing references to the source of the error
+    ['pointer' => '/test/foo/bar', 'parameter' => 'wrong'], 
+    // meta: a meta object containing non-standard meta-information about the error.
+    ['some' => 'meta info']                     
+);
+
+// retriving Error Object from an Exception:
+try {
+  // ...do stuff
+} catch (Exception $e) {
+  $error->retrieveFromException($e)
+}
+
+// retrieving Error object from a ServerRequestInterface:
+$error->retrieveFromRequest($request);
+
+// converting to an array:
+$array = $error->export();
+
+// converting to a JSON string:
+$json = $error->exportJson();
+
+--

--- a/content/developer/Error Messages.adoc
+++ b/content/developer/Error Messages.adoc
@@ -2,13 +2,11 @@
 title: "Error Messages"
 ---
 
-ErrorMessage class
-------------------
+= ErrorMessage class
 
 Helper class for using log error messages.
 
-Usage
-~~~~~
+== Usage
 
 [source, php]
 --

--- a/content/developer/Error Messages.adoc
+++ b/content/developer/Error Messages.adoc
@@ -2,7 +2,7 @@
 title: "Error Messages"
 ---
 
-= ErrorMessage class
+== ErrorMessage class
 
 Helper class for using log error messages.
 

--- a/content/developer/Error Messages.adoc
+++ b/content/developer/Error Messages.adoc
@@ -2,8 +2,10 @@
 title: "Error Messages"
 ---
 
-Error Messages
---------------
+ErrorMessage class
+------------------
+
+Helper class for using log error messages.
 
 Usage
 ~~~~~
@@ -17,6 +19,6 @@ ErrorMessage::log('An error occured for some reason');
 ErrorMessage::log('It\'s a debug message, only in debug level', 'debug');
 
 // critical error messages can throw an exception
-const OPTIONAL_ERROR_CODE = 1234;
-ErrorMessage::drop('Critical error occured for some reason', OPTIONAL_ERROR_CODE);
+const OPTIONAL_EXCEPTION_CODE = 1234;
+ErrorMessage::drop('Critical error occured for some reason', OPTIONAL_EXCEPTION_CODE); // throws new ErrorMessageException
 --

--- a/content/developer/Error Messages.adoc
+++ b/content/developer/Error Messages.adoc
@@ -1,0 +1,22 @@
+---
+title: "Error Messages"
+---
+
+Error Messages
+--------------
+
+Usage
+~~~~~
+
+[source, php]
+--
+// simply add an error message
+ErrorMessage::log('An error occured for some reason');
+
+// using different error level
+ErrorMessage::log('It\'s a debug message, only in debug level', 'debug');
+
+// critical error messages can throw an exception
+const OPTIONAL_ERROR_CODE = 1234;
+ErrorMessage::drop('Critical error occured for some reason', OPTIONAL_ERROR_CODE);
+--

--- a/content/developer/Exceptions and Localization.adoc
+++ b/content/developer/Exceptions and Localization.adoc
@@ -2,7 +2,7 @@
 Title: Exceptions and Localization
 ---
 
-= LangException class
+== LangException class
 
 Extension for PHP standard Exception with an extra LangText parameter, typical use case sending messages to users too.
 

--- a/content/developer/Exceptions and Localization.adoc
+++ b/content/developer/Exceptions and Localization.adoc
@@ -5,7 +5,7 @@ Title: Exceptions and Localization
 LangException class
 -------------------
 
-Extension for PHP standar Exception with an extra LangText parameter, tipically use case sending messages to users too.
+Extension for PHP standard Exception with an extra LangText parameter, typical use case sending messages to users too.
 
 Usage
 ~~~~~
@@ -22,7 +22,7 @@ try {
 } catch (LangException $e) {
 
   // using logger to inform the developer about the exception
-  $log = LoggerManager::getLoger();  
+  $log = LoggerManager::getLogger();  
   $log->fatal('Exception happend in the example: ' . $e->getMessage() . ', code: ' . $e->getCode());
   
   // using SugarApplication to inform the user about the problem with translated message:

--- a/content/developer/Exceptions and Localization.adoc
+++ b/content/developer/Exceptions and Localization.adoc
@@ -2,13 +2,11 @@
 Title: Exceptions and Localization
 ---
 
-LangException class
--------------------
+= LangException class
 
 Extension for PHP standard Exception with an extra LangText parameter, typical use case sending messages to users too.
 
-Usage
-~~~~~
+== Usage
 
 [source, php]
 --

--- a/content/developer/Exceptions and Localization.adoc
+++ b/content/developer/Exceptions and Localization.adoc
@@ -5,7 +5,7 @@ Title: Exceptions and Localization
 LangException class
 -------------------
 
-Extension for PHP standar Exception with an extra LangText parameter, tipically use case to send messages to users too.
+Extension for PHP standar Exception with an extra LangText parameter, tipically use case sending messages to users too.
 
 Usage
 ~~~~~
@@ -15,11 +15,13 @@ Usage
 try {
 
   // throw new LangException with located exception message:
-  thow new LangException('Exception message for developers', EXCEPTION_CODE, null, new LangText('LBL_TRANSLATABLE_USER_MESSAGE'));
+  thow new LangException(
+    'Exception message for developers', EXCEPTION_CODE, null, 
+    new LangText('LBL_TRANSLATABLE_USER_MESSAGE'));
   
 } catch (LangException $e) {
 
-  // using loger to inform the developer about the exception
+  // using logger to inform the developer about the exception
   $log = LoggerManager::getLoger();  
   $log->fatal('Exception happend in the example: ' . $e->getMessage() . ', code: ' . $e->getCode());
   

--- a/content/developer/Exceptions and Localization.adoc
+++ b/content/developer/Exceptions and Localization.adoc
@@ -1,0 +1,30 @@
+---
+Title: Exceptions and Localization
+---
+
+LangException class
+-------------------
+
+Extension for PHP standar Exception with an extra LangText parameter, tipically use case to send messages to users too.
+
+Usage
+~~~~~
+
+[source, php]
+--
+try {
+
+  // throw new LangException with located exception message:
+  thow new LangException('Exception message for developers', EXCEPTION_CODE, null, new LangText('LBL_TRANSLATABLE_USER_MESSAGE'));
+  
+} catch (LangException $e) {
+
+  // using loger to inform the developer about the exception
+  $log = LoggerManager::getLoger();  
+  $log->fatal('Exception happend in the example: ' . $e->getMessage() . ', code: ' . $e->getCode());
+  
+  // using SugarApplication to inform the user about the problem with translated message:
+  SugarApplication::appendErrorMessage($e->getLangMessage());
+}
+
+--

--- a/content/developer/JSON API Error Object.adoc
+++ b/content/developer/JSON API Error Object.adoc
@@ -1,0 +1,54 @@
+---
+Title: JSON API Error Object
+---
+
+JSON API Error Object
+---------------------
+
+Implementation of JSON API Error Object Specification. 
+See more: http://jsonapi.org/format/#error-objects[^]
+
+Usage
+~~~~~
+
+[source,php]
+--
+
+// creating a new Error Object:
+$error = new JsonApiErrorObject();
+
+// set some know data about the error:
+$error->setTitle(new LangText('LBL_ERROR_LABEL_TITLE'));
+$error->setDetail(new LangText('LBL_ERROR_LABEL_DETAIL'));
+$error->setCode(ERROR_CODE);
+// etc.. see more in source and phpDoc
+
+// creating new Error Object with known data directly in constructor, all parameters are optional:
+$error = new JsonApiErrorObject(
+    new LangText('LBL_ERROR_LABEL_TITLE'),      // title: a short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem, except for purposes of localization.
+    new LangText('LBL_ERROR_LABEL_DETAIL'),     // detail: a human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.
+    ERROR_ID,                                   // id: a unique identifier for this particular occurrence of the problem.
+    ERROR_CODE,                                 // code: an application-specific error code, expressed as a string value.
+    STATUS,                                     // status: the HTTP status code applicable to this problem, expressed as a string value.
+    ['about' => 'Descrioption about the problem'],          // links: a links object
+    ['pointer' => '/test/foo/bar', 'parameter' => 'wrong'], // source: an object containing references to the source of the error
+    ['some' => 'meta info']                     // meta: a meta object containing non-standard meta-information about the error.
+);
+
+// retriving Error Object from an Exception:
+try {
+  // ...do stuff
+} catch (Exception $e) {
+  $error->retrieveFromException($e)
+}
+
+// retrieving Error object from a ServerRequestInterface:
+$error->retrieveFromRequest($request);
+
+// converting to an array:
+$error->export();
+
+// converting to a JSON string:
+$error->exportJson();
+
+--

--- a/content/developer/JSON API Error Object.adoc
+++ b/content/developer/JSON API Error Object.adoc
@@ -2,7 +2,7 @@
 Title: JSON API Error Object
 ---
 
-= JsonApiErrorObject class
+== JsonApiErrorObject class
 
 Implementation of JSON API Error Object Specification. 
 See more: http://jsonapi.org/format/#error-objects[^]

--- a/content/developer/JSON API Error Object.adoc
+++ b/content/developer/JSON API Error Object.adoc
@@ -2,7 +2,7 @@
 Title: JSON API Error Object
 ---
 
-JSON API Error Object
+JsonApiErrorObject class
 ---------------------
 
 Implementation of JSON API Error Object Specification. 
@@ -25,14 +25,22 @@ $error->setCode(ERROR_CODE);
 
 // creating new Error Object with known data directly in constructor, all parameters are optional:
 $error = new JsonApiErrorObject(
-    new LangText('LBL_ERROR_LABEL_TITLE'),      // title: a short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem, except for purposes of localization.
-    new LangText('LBL_ERROR_LABEL_DETAIL'),     // detail: a human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.
-    ERROR_ID,                                   // id: a unique identifier for this particular occurrence of the problem.
-    ERROR_CODE,                                 // code: an application-specific error code, expressed as a string value.
-    STATUS,                                     // status: the HTTP status code applicable to this problem, expressed as a string value.
-    ['about' => 'Descrioption about the problem'],          // links: a links object
-    ['pointer' => '/test/foo/bar', 'parameter' => 'wrong'], // source: an object containing references to the source of the error
-    ['some' => 'meta info']                     // meta: a meta object containing non-standard meta-information about the error.
+    // title: a short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem, except for purposes of localization.
+    new LangText('LBL_ERROR_LABEL_TITLE'),      
+    // detail: a human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.
+    new LangText('LBL_ERROR_LABEL_DETAIL'),     
+    // id: a unique identifier for this particular occurrence of the problem.
+    ERROR_ID,                                   
+    // code: an application-specific error code, expressed as a string value.
+    ERROR_CODE,                                 
+    // status: the HTTP status code applicable to this problem, expressed as a string value.
+    STATUS,                                     
+    // links: a links object
+    ['about' => 'Descrioption about the problem'],          
+    // source: an object containing references to the source of the error
+    ['pointer' => '/test/foo/bar', 'parameter' => 'wrong'], 
+    // meta: a meta object containing non-standard meta-information about the error.
+    ['some' => 'meta info']                     
 );
 
 // retriving Error Object from an Exception:
@@ -46,9 +54,9 @@ try {
 $error->retrieveFromRequest($request);
 
 // converting to an array:
-$error->export();
+$array = $error->export();
 
 // converting to a JSON string:
-$error->exportJson();
+$json = $error->exportJson();
 
 --

--- a/content/developer/JSON API Error Object.adoc
+++ b/content/developer/JSON API Error Object.adoc
@@ -2,14 +2,12 @@
 Title: JSON API Error Object
 ---
 
-JsonApiErrorObject class
-------------------------
+= JsonApiErrorObject class
 
 Implementation of JSON API Error Object Specification. 
 See more: http://jsonapi.org/format/#error-objects[^]
 
-Usage
-~~~~~
+== Usage
 
 [source,php]
 --

--- a/content/developer/JSON API Error Object.adoc
+++ b/content/developer/JSON API Error Object.adoc
@@ -17,7 +17,7 @@ Usage
 // creating a new Error Object:
 $error = new JsonApiErrorObject();
 
-// set some know data about the error:
+// set some known data about the error:
 $error->setTitle(new LangText('LBL_ERROR_LABEL_TITLE'));
 $error->setDetail(new LangText('LBL_ERROR_LABEL_DETAIL'));
 $error->setCode(ERROR_CODE);

--- a/content/developer/JSON API Error Object.adoc
+++ b/content/developer/JSON API Error Object.adoc
@@ -3,7 +3,7 @@ Title: JSON API Error Object
 ---
 
 JsonApiErrorObject class
----------------------
+------------------------
 
 Implementation of JSON API Error Object Specification. 
 See more: http://jsonapi.org/format/#error-objects[^]

--- a/content/developer/Translate strings.adoc
+++ b/content/developer/Translate strings.adoc
@@ -1,0 +1,36 @@
+---
+Title: Translate strings
+---
+
+LangText class
+--------------
+
+Helper class to translate strings.
+
+Usage
+~~~~~
+
+[source,php]
+--
+// example string definition (only for understansing the next examples):
+$app_strings['LBL_EXAMPLE_APP_STR'] = 'Example Application String';
+$mod_strings['LBL_EXAMPLE_MOD_STR'] = 'Example string for a specified module';
+$mod_strings['LBL_EXAMPLE_VARIABLE'] = 'Example string to use value of {foo}';
+
+
+// Using translation for any strings
+$text = new LangText('LBL_EXAMPLE_APP_STR');
+echo $text;
+
+// Using translation for any strings with replaced strings values
+$text = new LangText('LBL_EXAMPLE_VARIABLE', ['foo' => 'bar']);
+echo $text; // output: Example string to use value of bar
+
+// Using translation only for Module Strings
+$text = new LangText('LBL_EXAMPLE_MOD_STR', null, LangText::USING_MOD_STRINGS);
+echo $text;
+
+// Using translation only for Application Strings
+$text = new LangText('LBL_EXAMPLE_APP_STR', null, LangText::USING_APP_STRINGS);
+echo $text;
+--

--- a/content/developer/Translate strings.adoc
+++ b/content/developer/Translate strings.adoc
@@ -2,13 +2,11 @@
 Title: Translate strings
 ---
 
-LangText class
---------------
+== LangText class
 
 Helper class to translate strings.
 
-Usage
-~~~~~
+== Usage
 
 [source,php]
 --

--- a/content/developer/Translate strings.adoc
+++ b/content/developer/Translate strings.adoc
@@ -12,7 +12,7 @@ Usage
 
 [source,php]
 --
-// example string definition (only for understansing the next examples):
+// example string definition (only for understanding the next examples):
 $app_strings['LBL_EXAMPLE_APP_STR'] = 'Example Application String';
 $mod_strings['LBL_EXAMPLE_MOD_STR'] = 'Example string for a specified module';
 $mod_strings['LBL_EXAMPLE_VARIABLE'] = 'Example string to use value of {foo}';


### PR DESCRIPTION
Documentation added for:
- json api error object
- error messages
- translation for exceptions
- translations for strings

Please do not merge it until if related PR also merged into SuiteCRM repository:
https://github.com/salesagility/SuiteCRM/pull/5528
