### PR TITLE
Add git commands on how to branch from an upstream branch

### DIFF
--- a/content/community/contributing-code/Bugs.adoc
+++ b/content/community/contributing-code/Bugs.adoc
@@ -20,6 +20,10 @@ hotfix branch.
 * Separate each issue fix into a new branch in your repository (Either
 from the `hotfix-7.8.x` or `hotfix` branch) and name it with the issue
 ID e.g. _bugfix_3062_ or _issue-1234_.
++
+e.g. to create the branch from `hotfix-7.8.x` with the following git command:
++
+`git checkout -b _bugfix_3062_ upstream/hotfix-7.8.x`
 
 * When committing to your individual bugfix branch, it helps to follow
 the message format below:
@@ -35,6 +39,11 @@ fixes within major and minor link:Release_notes_7.6[release notes].
 +
 If you are new to Writing Commit Messages in git follow the guide
 http://chris.beams.io/posts/git-commit/#seven-rules[here].
+
+* When pushing a branch that has bean created from an upstream branch 
+to your remote fork, you will need to specify "origin", e.g.
++
+`git push origin _bugfix_3062_`
 
 === Make a Bug Fix Pull Request
 


### PR DESCRIPTION
The documentation didn't explain on how to branch off of one of the hotfix branches.

The fact that the created fork does not display these branches makes it hard to find out how to create such a branch. Creating such a branch from the forked master leads to very complicated pull requests.

I also included a simple push command to origin, as origin is mandatory when branching off of an upstream branch.

