### PR TITLE
example references undeclared variable

### DIFF
--- a/content/developer/Scheduled Tasks.adoc
+++ b/content/developer/Scheduled Tasks.adoc
@@ -136,7 +136,8 @@ class SomeClass
          $admin->retrieveSettings();
          $admin->settings['notify_fromname']
          $mailer->From     = $admin->settings['notify_fromaddress']
-         $mailer->FromName = $emailSettings['from_name'];
+         $mailer->FromName = $admin->settings['notify_fromname'];
+         
          $mailer->IsHTML(true);
  
          //Add message and recipient.


### PR DESCRIPTION
$emailSettings is undeclared and raises a warning.
$mailer->FromName = $emailSettings['from_name'];