### PR TITLE
Update JSON-API.adoc

### DIFF
--- a/content/developer/api/version-8/JSON-API.adoc
+++ b/content/developer/api/version-8/JSON-API.adoc
@@ -42,8 +42,7 @@ Also, you have to be sure that the config files are owned by PHP.
 sudo chown www-data:www-data p*.key
 
 === Update encryption key
-
-OAuth2's AuthorizationServer needs to set an encryption key for security reasons. For doing this, please, go to `Api/V8/Config/services/middlewares.php` and find the row starts with `$server->setEncryptionKey('');`
+OAuth2’s AuthorizationServer needs to set an encryption key for security reasons. For doing this, please, go to Api/Core/Config/ApiConfig.php and find "const OAUTH2_ENCRYPTION_KEY".
 
 Now update its value with generating a new one using `base64_encode(random_bytes(32))`
 


### PR DESCRIPTION
To change the const that is read seems to be the correct way to do this, instead of changing the value where the const is read from.
I have not checked if this const is used other places, (with different purpose) but if it is, there should probably be more keys added to the ApiConfig.php instead.