### PR TITLE
Update the code-standards copyright header for 2019

### DIFF
--- a/content/community/contributing-code/Coding Standards.adoc
+++ b/content/community/contributing-code/Coding Standards.adoc
@@ -25,7 +25,7 @@ as the standard header
  * SugarCRM, Inc. Copyright (C) 2004-2013 SugarCRM Inc. 
  * 
  * SuiteCRM is an extension to SugarCRM Community Edition developed by SalesAgility Ltd. 
- * Copyright (C) 2011 - 2018 SalesAgility Ltd. 
+ * Copyright (C) 2011 - 2019 SalesAgility Ltd. 
  * 
  * This program is free software; you can redistribute it and/or modify it under 
  * the terms of the GNU Affero General Public License version 3 as published by the 


### PR DESCRIPTION
Updates the code-standards page for copyright header to be for the year 2019.