### PR TITLE
Document the multienum type in the Vardefs docs.

### DIFF
--- a/content/developer/Vardefs.adoc
+++ b/content/developer/Vardefs.adoc
@@ -170,6 +170,8 @@ The following are common field types used:
   A date and time field.
 `enum`::
   A dropdown field.
+`multienum`::
+  A dropdown field that allows selecting multiple values.
 `phone`::
   A phone number field.
 `link`::


### PR DESCRIPTION
This wasn't documented but it definitely works in SuiteCRM, so I've added it. 

Changes this page: https://docs.suitecrm.com/developer/vardefs/

The actual code in SuiteCRM where the multienum type is defined: https://github.com/salesagility/SuiteCRM/blob/ef1b41965c056937894dd3018d3b149c9c25a9a9/include/SugarFields/Fields/Multienum/SugarFieldMultienum.php