### PR TITLE
Update Oauth2 auth

### DIFF
--- a/content/developer/api/version-8/Configure Authentication.adoc
+++ b/content/developer/api/version-8/Configure Authentication.adoc
@@ -65,7 +65,7 @@ image:Admin-OAuth2Clients-5.png[View a Client Credentials Client]
 === Authentication with Client Credentials
 
 [source,php]
-POST /api/oauth/access_token
+POST /Api/access_token
 
 [[required-parameters]]
 Required parameters
@@ -77,7 +77,6 @@ Required parameters
 |grant_type |client_credentials
 |client_id |*ExampleClientName*
 |client_secret |*ExampleSecretPassword*
-|scope | standard:create standard:read standard:update standard:delete standard:delete standard:relationship:create standard:relationship:read standard:relationship:update standard:relationship:delete
 |======================================
 
 
@@ -92,9 +91,8 @@ $postStr = json_encode(array(
     'grant_type' => 'client_credentials',
     'client_id' => '3D7f3fda97-d8e2-b9ad-eb89-5a2fe9b07650',
     'client_secret' => 'client_secret',
-    'scope' => 'standard:create standard:read standard:update standard:delete standard:delete standard:relationship:create standard:relationship:read standard:relationship:update standard:relationship:delete'
 ));
-$url = 'https://path-to-instance/api/oauth/access_token';
+$url = 'https://path-to-instance/Api/access_token';
 curl_setopt($ch, CURLOPT_URL, url);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
 curl_setopt($ch, CURLOPT_POSTFIELDS, $postStr);
@@ -108,7 +106,6 @@ $output = curl_exec($ch);
    "token_type":"Bearer",
    "expires_in":3600,
    "access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6IjdkOTEyODNhMjc1NDdkNDRlMzNmOTc5ZjVmMGRkYzQwNzg1ZGY5NGFhMWI5MDVlZGNmMzg3NWIxYjJkZDMzNDljZWEyNjZhMTQ2OTE5OWIzIn0.eyJhdWQiOiJzdWl0ZWNybV9jbGllbnQiLCJqdGkiOiI3ZDkxMjgzYTI3NTQ3ZDQ0ZTMzZjk3OWY1ZjBkZGM0MDc4NWRmOTRhYTFiOTA1ZWRjZjM4NzViMWIyZGQzMzQ5Y2VhMjY2YTE0NjkxOTliMyIsImlhdCI6MTUxODE5NTEwMiwibmJmIjoxNTE4MTk1MTAyLCJleHAiOjE1MTgxOTg3MDIsInN1YiI6IjEiLCJzY29wZXMiOltdfQ.EVGuRisoMxSIZut3IWtgOYISw8lEFSZgCWYCwseLEfOuPJ8lRMYL4OZxhu9gxJoGF0nj3yc6SYDPxovrsoj8bMoX38h4krMMOHFQLoizU0k2wAceOjZG1tWKPhID7KPT4TwoCXbb7MqAsYtVPExH4li7gSphJ8wvcWbFdS5em89Ndtwqq3faFtIq6bv1R4t0x98HHuT7sweHUJU40K9WQjbAfIOk8f5Y6T2wassN2wMCBB8CC6eUxLi14n2D6khHvkYvtPbXLHpXSHZWvEhqhvjAeSR5MmMrAth9WDSWUx7alO-ppsZpi8U7-g9Be5p6MRatc25voyTI2iTYbx02FQ",
-   "refresh_token":"def50200d2fb757e4c01c333e96c827712dfd8f3e2c797db3e4e42734c8b4e7cba88a2dd8a9ce607358d634a51cadd7fa980d5acd692ab2c7a7da1d7a7f8246b22faf151dc11a758f9d8ea0b9aa3553f3cfd3751a927399ab964f219d086d36151d0f39c93aef4a846287e8467acea3dfde0bd2ac055ea7825dfb75aa5b8a084752de6d3976438631c3e539156a26bc10d0b7f057c092fce354bb10ff7ac2ab5fe6fd7af3ec7fa2599ec0f1e581837a6ca2441a80c01d997dac298e1f74573ac900dd4547d7a2a2807e9fb25438486c38f25be55d19cb8d72634d77c0a8dfaec80901c01745579d0f3822c717df21403440473c86277dc5590ce18acdb1222c1b95b516f3554c8b59255446bc15b457fdc17d5dcc0f06f7b2252581c810ca72b51618f820dbb2f414ea147add2658f8fbd5df20820843f98c22252dcffe127e6adb4a4cbe89ab0340f7ebe8d8177ef382569e2aa4a54d434adb797c5337bfdfffe27bd8d5cf4714054d4aef2372472ebb4"
 }
 
 
@@ -122,8 +119,6 @@ $output = curl_exec($ch);
 the authorization server’s private key. It is required that you include
 this in the HTTP headers, each time you make a request to the API
 
-|*refresh_token* |an encrypted payload that can be used to refresh the
-access token when it expires.
 |=======================================================================
 
 You can store the bearer token in a database and use in your requests
@@ -166,7 +161,7 @@ client is saved.
 image:Admin-OAuth2Clients-7.png[View a password grant client]
 
 [source,php]
-POST /api/oauth/access_token
+POST /Api/access_token
 
 [[required-parameters-1]]
 Required parameters
@@ -178,7 +173,6 @@ Required parameters
 |grant_type |password
 |client_id |*ExampleClientName*
 |client_secret |*ExampleSecretPassword*
-|scope | standard:create standard:read standard:update standard:delete standard:delete standard:relationship:create standard:relationship:read standard:relationship:update standard:relationship:delete
 |username |*admin*
 |password |*secret*
 |======================================
@@ -199,9 +193,8 @@ $postStr = json_encode(array(
     'client_secret' => 'client_secret',
     'username' => 'admin',
     'password' => 'admin',
-    'scope' => 'standard:create standard:read standard:update standard:delete standard:delete standard:relationship:create standard:relationship:read standard:relationship:update standard:relationship:delete'
 ));
-$url = 'https://path-to-instance/api/oauth/access_token';
+$url = 'https://path-to-instance/Api/access_token';
 curl_setopt($ch, CURLOPT_URL, url);
 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
 curl_setopt($ch, CURLOPT_POSTFIELDS, $postStr);


### PR DESCRIPTION
- Updated the Oauth2 authentication configuration page to point towards the new V8 access_token path
- Removed 'scope' which is currently not implemented in the V8 API.
- Removed refresh_token from client_credentials. See Oauth2 docs and issue reference for details.

Issue reference: https://github.com/salesagility/SuiteCRM/issues/6141
Further context: https://github.com/salesagility/SuiteCRM/issues/7083

Oauth2 docs: https://oauth2.thephpleague.com/
Oauth2 RFC: https://tools.ietf.org/html/rfc6749