### PR TITLE
Split automated testing documentation into multiple files

### DIFF
--- a/content/developer/Appendix C - Automated Testing.adoc
+++ b/content/developer/Appendix C - Automated Testing.adoc
@@ -18,9 +18,9 @@ Automated testing provides a means to ensure that the high quality of SuiteCRM i
 
 In your terminal emulator or command prompt:
 
-`cd /path/to/suitecrm/instance`
+`cd path/to/suitecrm/instance`
 
-Run the command:
+Install dependencies from Composer:
 
 `composer install`
 
@@ -32,17 +32,17 @@ SuiteCRM offers many different test suites.
 |=======================================================================
 | Suite      | Description
 
+| install    | Acceptance test to test that the install wizard is working correctly
 | acceptance | Automated browser testing, also known as 'feature tests'
 | unit       | Unit tests reflect that a single unit of code, e.g. a method, is working
 | api        | Functional tests which test the API version 8 responses
-| install    | Acceptance test to test that the install wizard is working correctly
 |=======================================================================
 
 
 === Running Codeception for the first time
-Codeception and the other commands live inside the `vendor/bin/`` directory of your SuiteCRM instance. To test that your configuration is working you need to first install your copy of SuiteCRM. After installing SuiteCRM you can run the acceptance tests:
+Codeception and the other commands live inside the `vendor/bin/` directory of your SuiteCRM instance. To test that your configuration is working you need to first install your copy of SuiteCRM. After installing SuiteCRM and downloading ChromeDriver you can run the acceptance tests:
 
-`./vendor/bin/codecept run unit`
+`./vendor/bin/codecept run acceptance`
 
 
 == Requirements
@@ -51,11 +51,11 @@ Each tests suite has its own set of requirements.
 
 === Unit tests
 
-To run the unit test, you just need to the install the testing framework.
+To run the unit test, you just need to install the testing framework.
 
-You can continue to run the unit test suite using the command:
+You can run the unit tests with the following:
 
-`./vendor/bin/phpunit --colors --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit`
+- `./vendor/bin/phpunit --colors --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit`
 
 === API tests
 
@@ -69,16 +69,18 @@ You can run the api test suite using the command:
 
 The acceptance and install tests require the test environment to be configured.
 
+They also require ChromeDriver to be running so the tests can connect to Chrome.
+
 You can run the acceptance test suite using the command:
 
 `./vendor/bin/codecept run acceptance`
 
-You can run the api test suite using the command:
+You can run the install test suite using the command:
 
-`./vendor/bin/codecept run api`
+`./vendor/bin/codecept run install`
 
 
-== Add vendor bin to your PATH
+== Add `vendor/bin` to your PATH
 
 This will make it easier to run codeception and the other commands which live in vendor/bin/ directory. You can add the vendor/bin location to your PATH environment variable.
 
@@ -90,7 +92,7 @@ This will make it easier to run codeception and the other commands which live in
 
 `set PATH=%PATH%;C:\path\to\instance\vendor\bin`
 
-This allows you to call the codecept command without having to prefix the command with its location. When running codecept you should ensure that your current working directory is the same as your suitecrm instance.
+This allows you to call the codecept command without having to prefix the command with its location. When running codecept you should ensure that your current working directory is the same as your SuiteCRM instance.
 
 `cd /path/to/suitecrm/instance/`
 
@@ -143,13 +145,14 @@ You can automate different development environments using environment variables.
 |=======================================================================
 
 ==== Setup environment variables (bash):
-Open terminal and run Robo
+
+Open terminal and run Robo:
 
 `./vendor/bin/robo configure:tests`
 
 ==== Setup environment variables (Command Prompt):
 
-Open terminal and run Robo
+Open terminal and run Robo:
 
 `.\vendor\bin\robo configure:tests`
 
@@ -206,7 +209,7 @@ It is also possible to run multi environments at the same time by adding multipl
 
 `codecept run acceptance --env selenium-hub,selenium-iphone-6  --env selenium-hub,selenium-hd`
 
-The tests will be executed 2 times, once for each environment
+The tests will be executed 2 times, once for each environment.
 
 
 === Selenium

--- a/content/developer/automatedtesting/TestingEnvironment.adoc
+++ b/content/developer/automatedtesting/TestingEnvironment.adoc
@@ -8,13 +8,13 @@ SuiteCRM provides an automated to task to assist with the configuration of the t
 
 === Configure Testing Environment (bash):
 
-Open terminal and run robo
+Open terminal and run Robo:
 
 `./vendor/bin/robo configure:tests`
 
-=== Configure Testing Environment(Command Prompt):
+=== Configure Testing Environment (Command Prompt):
 
-Open Command Prompt and run robo
+Open Command Prompt and run Robo:
 
 `.\vendor\bin\robo configure:tests`
 

--- a/content/developer/automatedtesting/Writing Tests.adoc
+++ b/content/developer/automatedtesting/Writing Tests.adoc
@@ -1,302 +1,14 @@
 
 ---
 weight: 23
-title: "Appendix C - Automated Testing"
+title: "Automated Testing"
 ---
-
-:imagesdir: ./../../../images/en/developer
 
 :toc:
 :toclevels: 4
 
 
-== Introduction
-
-Automated testing provides a means to ensure that the high quality of SuiteCRM is maintained. SuiteCRM has an automated test suite which is powered by the http://codeception.com[codeception] testing framework.
-
-=== Installing the testing framework
-
-In your terminal emulator or command prompt:
-
-`cd path/to/suitecrm/instance`
-
-Install dependencies from Composer:
-
-`composer install`
-
-== Test Suites
-
-SuiteCRM offers many different test suites.
-
-[width="80",cols="30,50",options="header",]
-|=======================================================================
-| Suite      | Description
-
-| install    | Acceptance test to test that the install wizard is working correctly
-| acceptance | Automated browser testing, also known as 'feature tests'
-| unit       | Unit tests reflect that a single unit of code, e.g. a method, is working
-| api        | Functional tests which test the API version 8 responses
-|=======================================================================
-
-
-=== Running Codeception for the first time
-Codeception and the other commands live inside the `vendor/bin/` directory of your SuiteCRM instance. To test that your configuration is working you need to first install your copy of SuiteCRM. After installing SuiteCRM and downloading ChromeDriver you can run the acceptance tests:
-
-`./vendor/bin/codecept run acceptance`
-
-
-== Requirements
-
-Each tests suite has its own set of requirements.
-
-=== Unit tests
-
-To run the unit test, you just need to install the testing framework.
-
-You can run the unit tests with the following:
-
-- `./vendor/bin/phpunit --colors --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit`
-
-=== API tests
-
-The API tests require that you import the database (or `.sql`) files which exist the `tests/_data` folder. You also need to configure the test environment variables.
-
-You can run the api test suite using the command:
-
-`./vendor/bin/codecept run api`
-
-=== Acceptance and Install tests
-
-The acceptance and install tests require the test environment to be configured.
-
-They also require ChromeDriver to be running so the tests can connect to Chrome.
-
-You can run the acceptance test suite using the command:
-
-`./vendor/bin/codecept run acceptance`
-
-You can run the install test suite using the command:
-
-`./vendor/bin/codecept run install`
-
-
-== Add `vendor/bin` to your PATH
-
-This will make it easier to run codeception and the other commands which live in vendor/bin/ directory. You can add the vendor/bin location to your PATH environment variable.
-
-*Adding vendor/bin to PATH (Bash):*
-
-`export PATH=$PATH:/path/to/instance/vendor/bin`
-
-*Adding vendor/bin to PATH (Command Prompt):*
-
-`set PATH=%PATH%;C:\path\to\instance\vendor\bin`
-
-This allows you to call the codecept command without having to prefix the command with its location. When running codecept you should ensure that your current working directory is the same as your SuiteCRM instance.
-
-`cd /path/to/suitecrm/instance/`
-
-`codecept run acceptance`
-
-== Configuring the test environment
-
-SuiteCRM requires you to configure the automated test with your development environment. There are a number of ways to configure your environment.
-
-* You can configure the automated tests by adding a `.yml` file to the `tests/_envs` folder
-* You can edit the `.yml` files for each test suite
-* You can set up environment variables in the terminal or command prompt (recommended)
-
-
-=== Environment Variables
-
-This is the preferred method to store sensitive information, as it prevents security information from being committed to the git repository.
-You can automate different development environments using environment variables.
-
-==== Test Suite Requirements
-
-*Install Test Suite:*
-
-[width="80",cols="30,50",options="header",]
-|=======================================================================
-| Variable          | Description
-
-| DATABASE_DRIVER   | MYSQL or MSSQL
-| DATABASE_HOST     | path to database server
-| DATABASE_NAME     | name of the database
-| DATABASE_USER     | database user
-| DATABASE_PASSWORD | database password
-|=======================================================================
-
-*Acceptance, API, and Install Test Suites:*
-|=======================================================================
-| Variable                | Description
-
-| INSTANCE_URL            | URL of the SuiteCRM instance which the tester need to access
-| INSTANCE_ADMIN_USER     | admin user for logging in
-| INSTANCE_ADMIN_PASSWORD | admin password for logging in
-|=======================================================================
-
-
-*API Test Suites:*
-|=======================================================================
-| Variable               | Description
-| INSTANCE_CLIENT_ID     | ID of the client
-| INSTANCE_CLIENT_SECRET | Secret of the client
-|=======================================================================
-
-==== Setup environment variables (bash):
-
-Open terminal and run Robo:
-
-`./vendor/bin/robo configure:tests`
-
-==== Setup environment variables (Command Prompt):
-
-Open terminal and run Robo:
-
-`.\vendor\bin\robo configure:tests`
-
-==== Setup environment variables (Docker Compose):
-
-You can add a `.env` file into your Docker Compose setup:
-
-[source,bash]
-DATABASE_DRIVER=MYSQL
-DATABASE_NAME=automated_tests
-DATABASE_HOST=localhost
-DATABASE_USER=automated_tests
-DATABASE_PASSWORD=automated_tests
-INSTANCE_URL=http://path/to/instance
-INSTANCE_ADMIN_USER=admin
-INSTANCE_ADMIN_PASSWORD=admin
-INSTANCE_CLIENT_ID=suitecrm_client
-INSTANCE_CLIENT_SECRET=secret
-
-then reference it in your php container (`docker-compose.yml`):
-
-[source,docker]
-version: '3'
-services:
-  php:
-      image: php:7.0-apache
-      restart: always
-      ports:
-        - 9001:80
-      environment:
-       - DATABASE_DRIVER: $DATABASE_DRIVER
-       - DATABASE_NAME: $DATABASE_NAME
-       - DATABASE_HOST: $DATABASE_HOST
-       - DATABASE_USER: $DATABASE_USER
-       - DATABASE_PASSWORD: $DATABASE_PASSWORD
-       - INSTANCE_URL: $INSTANCE_URL
-       - INSTANCE_ADMIN_USER: $INSTANCE_ADMIN_USER
-       - INSTANCE_ADMIN_PASSWORD: $INSTANCE_ADMIN_PASSWORD
-       - INSTANCE_CLIENT_ID: $INSTANCE_CLIENT_ID
-       - INSTANCE_CLIENT_SECRET: $INSTANCE_CLIENT_SECRET
-
-== Running the test environment
-
-The SuiteCRM automated testing framework can support different environments. You can see the different configurations for test environments in `tests/_env` folder. There are different prefixes fore each testing environment you choose to deploy.
-
-* selenium - Configures the features for selenium web driver environment
-* travis-ci - Configures features for travis-ci environment
-
-To run the tests in a single environment, add a `--env` flag to the codecept command; separating each configuration by a comma:
-
-`codecept run acceptance --env selenium-hub,selenium-iphone-6`
-
-It is also possible to run multi environments at the same time by adding multiple --env flags:
-
-`codecept run acceptance --env selenium-hub,selenium-iphone-6  --env selenium-hub,selenium-hd`
-
-The tests will be executed 2 times, once for each environment.
-
-
-=== Selenium
-
-The SuiteCRM testing framework can be configured to use selenium as the browser service.
-
-==== Using Selenium with a local PHP environment
-
-You may prefer to run in a local PHP environment instead of using Docker Compose. This requires you to have Selenium running locally on your computer. When running in a local environment you do not need to include the selenium-hub environment variable. Instead, you must choose whichever browser you have set up locally:
-
-`codecept run acceptance --env selenium-chrome`
-
-
-==== Using Docker Compose with the Selenium Hub
-
-In your selenium development environment it is recommended that you employ docker compose to set up a selenium hub with a selenium node. This will ensure your version of Chrome or Firefox is kept up-to-date with the latest version. In addition, you can also run multiple versions of PHP on the same host machine.
-
-You can configure selenium using docker compose. Please ensure you have the following in your docker-compose.yml file.
-
-[source,docker]
-version: '3'
-services:
-    selenium-hub:
-      image: selenium/hub
-      restart: always
-      ports:
-        - 4444:4444
-    selenium-node-chrome:
-      image: selenium/node-chrome-debug
-      restart: always
-      ports:
-        - 5900:5900
-      links:
-        - selenium-hub:hub
-      environment:
-              - "HUB_PORT_4444_TCP_ADDR=selenium-hub"
-              - "HUB_PORT_4444_TCP_PORT=4444"
-    selenium-node-firefox:
-      image: selenium/node-firefox-debug
-      restart: always
-      ports:
-        - 5901:5900
-      links:
-        - selenium-hub:hub
-      environment:
-              - "HUB_PORT_4444_TCP_ADDR=selenium-hub"
-              - "HUB_PORT_4444_TCP_PORT=4444"
-
-*Note: you can also choose different images for the nodes, for example the nodes without vnc support*
-
-
-==== Screen Resolutions / Fake Devices
-
-Here are the different configurations for each target device we test for:
-
-[width="80",cols="60,20",options="header",]
-|=======================================================================
-| Device            | Resolution
-
-| selenium-iphone-6 | 375x667
-| selenium-ipad-2   | 768x1024
-| selenium-xga      | 1024x768
-| selenium-hd       | 1280x720
-| selenium-fhd      | 1920x1080
-|=======================================================================
-
-==== Run Selenium Hub
-
-`codecept run acceptance --env selenium-hub,selenium-xga`
-
-*Please note:* that the SuiteCRM automated test framework uses *height* and *width* values to define the window size instead of the window_size. window_size is ignored by the automated test framework.
-
-
-==== Selecting Browser
-
-You can select the browser you wish to test by adding it to the --env.
-
-`codecept run acceptance --env selenium-hub,selenium-chrome`
-
-or
-
-`codecept run acceptance --env selenium-hub,selenium-firefox`
-
-== Writing and Running Tests
-
-
-=== PHPUnit tests
+== PHPUnit tests
 
 PHPUnit tests are related to a unit you are testing. The path of the tests is identical to the path of the unit inside the `tests/...` folder. Each Unit test class has a suffix `...Test` and should extend the `SuiteCRM\StateCheckerPHPUnitTestCaseAbstract` class. Test methods prefix is `test...`.
 
@@ -328,7 +40,7 @@ class ExampleTest extends StateCheckerPHPUnitTestCaseAbstract {
 
 See more about PHPUnit tests at https://phpunit.readthedocs.io
 
-=== Codeception Acceptance Tests
+== Codeception Acceptance Tests
 
 Implementation of state-safe acceptance tests.
 
@@ -378,7 +90,7 @@ Used in state checker tests.
 
  - Configuration of state checker tests - see `SuiteCRM\StateCheckerConfig` class.
 
-=== State-Safe Tests
+== State-Safe Tests
 `StateSaver` and `StateChecker`
 
 - State check library for SuperGlobals, FileSystem and DataBase etc.
@@ -1121,7 +833,7 @@ SuiteCRM config overrides:
 $sugar_config['state_checker']['php_configuration_option_keys']
 --
 
-=== How to: Testing Imap
+== How to: Testing Imap
 
 Developers able to write IMAP test (unit and acceptance tests).
 
@@ -1188,7 +900,7 @@ Example unit test for imap connection (using fake imap data)
      }
 --
 
-usefull config variables:
+useful config variables:
 [source, php]
 --
 $sugar_config['imap_test'] = true;
@@ -1202,4 +914,3 @@ $sugar_config['show_log_trace'] = false; // set to true for more details
 
 * http://codeception.com[codeception]
 * https://docs.seleniumhq.org/[Selenium]
-

--- a/content/developer/automatedtesting/Writing Tests.adoc
+++ b/content/developer/automatedtesting/Writing Tests.adoc
@@ -1,11 +1,9 @@
 
 ---
-weight: 23
-title: "Automated Testing"
+title: "Writing Tests"
 ---
 
 :toc:
-:toclevels: 4
 
 
 == PHPUnit tests

--- a/content/developer/automatedtesting/_index.en.adoc
+++ b/content/developer/automatedtesting/_index.en.adoc
@@ -1,6 +1,6 @@
 
 ---
-weight: 23
+weight: 19
 title: "Automated Testing"
 ---
 

--- a/content/developer/automatedtesting/_index.en.adoc
+++ b/content/developer/automatedtesting/_index.en.adoc
@@ -1,0 +1,293 @@
+
+---
+weight: 23
+title: "Automated Testing"
+---
+
+:toc:
+:toclevels: 4
+
+
+== Introduction
+
+Automated testing provides a means to ensure that the high quality of SuiteCRM is maintained. SuiteCRM has an automated test suite which is powered by the http://codeception.com[codeception] testing framework.
+
+=== Installing the testing framework
+
+In your terminal emulator or command prompt:
+
+`cd path/to/suitecrm/instance`
+
+Install dependencies from Composer:
+
+`composer install`
+
+== Test Suites
+
+SuiteCRM offers many different test suites.
+
+[width="80",cols="30,50",options="header",]
+|=======================================================================
+| Suite      | Description
+
+| install    | Acceptance test to test that the install wizard is working correctly
+| acceptance | Automated browser testing, also known as 'feature tests'
+| unit       | Unit tests reflect that a single unit of code, e.g. a method, is working
+| api        | Functional tests which test the API version 8 responses
+|=======================================================================
+
+
+=== Running Codeception for the first time
+Codeception and the other commands live inside the `vendor/bin/` directory of your SuiteCRM instance. To test that your configuration is working you need to first install your copy of SuiteCRM. After installing SuiteCRM and downloading ChromeDriver you can run the acceptance tests:
+
+`./vendor/bin/codecept run acceptance`
+
+
+== Requirements
+
+Each tests suite has its own set of requirements.
+
+=== Unit tests
+
+To run the unit test, you just need to install the testing framework.
+
+You can run the unit tests with the following:
+
+`./vendor/bin/phpunit --colors --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit`
+
+=== API tests
+
+The API tests require that you import the database (or `.sql`) files which exist the `tests/_data` folder. You also need to configure the test environment variables.
+
+You can run the api test suite using the command:
+
+`./vendor/bin/codecept run api`
+
+=== Acceptance and Install tests
+
+The acceptance and install tests require the test environment to be configured.
+
+They also require ChromeDriver to be running so the tests can connect to Chrome.
+
+You can run the acceptance test suite using the command:
+
+`./vendor/bin/codecept run acceptance`
+
+You can run the install test suite using the command:
+
+`./vendor/bin/codecept run install`
+
+
+== Add `vendor/bin` to your PATH
+
+This will make it easier to run codeception and the other commands which live in vendor/bin/ directory. You can add the vendor/bin location to your PATH environment variable.
+
+*Adding vendor/bin to PATH (Bash):*
+
+`export PATH=$PATH:/path/to/instance/vendor/bin`
+
+*Adding vendor/bin to PATH (Command Prompt):*
+
+`set PATH=%PATH%;C:\path\to\instance\vendor\bin`
+
+This allows you to call the codecept command without having to prefix the command with its location. When running codecept you should ensure that your current working directory is the same as your SuiteCRM instance.
+
+`cd /path/to/suitecrm/instance/`
+
+`codecept run acceptance`
+
+== Configuring the test environment
+
+SuiteCRM requires you to configure the automated test with your development environment. There are a number of ways to configure your environment.
+
+* You can configure the automated tests by adding a `.yml` file to the `tests/_envs` folder
+* You can edit the `.yml` files for each test suite
+* You can set up environment variables in the terminal or command prompt (recommended)
+
+
+=== Environment Variables
+
+This is the preferred method to store sensitive information, as it prevents security information from being committed to the git repository.
+You can automate different development environments using environment variables.
+
+==== Test Suite Requirements
+
+*Install Test Suite:*
+
+[width="80",cols="30,50",options="header",]
+|=======================================================================
+| Variable          | Description
+
+| DATABASE_DRIVER   | MYSQL or MSSQL
+| DATABASE_HOST     | path to database server
+| DATABASE_NAME     | name of the database
+| DATABASE_USER     | database user
+| DATABASE_PASSWORD | database password
+|=======================================================================
+
+*Acceptance, API, and Install Test Suites:*
+|=======================================================================
+| Variable                | Description
+
+| INSTANCE_URL            | URL of the SuiteCRM instance which the tester need to access
+| INSTANCE_ADMIN_USER     | admin user for logging in
+| INSTANCE_ADMIN_PASSWORD | admin password for logging in
+|=======================================================================
+
+
+*API Test Suites:*
+|=======================================================================
+| Variable               | Description
+| INSTANCE_CLIENT_ID     | ID of the client
+| INSTANCE_CLIENT_SECRET | Secret of the client
+|=======================================================================
+
+==== Setup environment variables (bash):
+
+Open terminal and run Robo:
+
+`./vendor/bin/robo configure:tests`
+
+==== Setup environment variables (Command Prompt):
+
+Open terminal and run Robo:
+
+`.\vendor\bin\robo configure:tests`
+
+==== Setup environment variables (Docker Compose):
+
+You can add a `.env` file into your Docker Compose setup:
+
+[source,bash]
+DATABASE_DRIVER=MYSQL
+DATABASE_NAME=automated_tests
+DATABASE_HOST=localhost
+DATABASE_USER=automated_tests
+DATABASE_PASSWORD=automated_tests
+INSTANCE_URL=http://path/to/instance
+INSTANCE_ADMIN_USER=admin
+INSTANCE_ADMIN_PASSWORD=admin
+INSTANCE_CLIENT_ID=suitecrm_client
+INSTANCE_CLIENT_SECRET=secret
+
+then reference it in your php container (`docker-compose.yml`):
+
+[source,docker]
+version: '3'
+services:
+  php:
+      image: php:7.0-apache
+      restart: always
+      ports:
+        - 9001:80
+      environment:
+       - DATABASE_DRIVER: $DATABASE_DRIVER
+       - DATABASE_NAME: $DATABASE_NAME
+       - DATABASE_HOST: $DATABASE_HOST
+       - DATABASE_USER: $DATABASE_USER
+       - DATABASE_PASSWORD: $DATABASE_PASSWORD
+       - INSTANCE_URL: $INSTANCE_URL
+       - INSTANCE_ADMIN_USER: $INSTANCE_ADMIN_USER
+       - INSTANCE_ADMIN_PASSWORD: $INSTANCE_ADMIN_PASSWORD
+       - INSTANCE_CLIENT_ID: $INSTANCE_CLIENT_ID
+       - INSTANCE_CLIENT_SECRET: $INSTANCE_CLIENT_SECRET
+
+== Running the test environment
+
+The SuiteCRM automated testing framework can support different environments. You can see the different configurations for test environments in `tests/_env` folder. There are different prefixes fore each testing environment you choose to deploy.
+
+* selenium - Configures the features for selenium web driver environment
+* travis-ci - Configures features for travis-ci environment
+
+To run the tests in a single environment, add a `--env` flag to the codecept command; separating each configuration by a comma:
+
+`codecept run acceptance --env selenium-hub,selenium-iphone-6`
+
+It is also possible to run multi environments at the same time by adding multiple --env flags:
+
+`codecept run acceptance --env selenium-hub,selenium-iphone-6  --env selenium-hub,selenium-hd`
+
+The tests will be executed 2 times, once for each environment.
+
+
+=== Selenium
+
+The SuiteCRM testing framework can be configured to use selenium as the browser service.
+
+==== Using Selenium with a local PHP environment
+
+You may prefer to run in a local PHP environment instead of using Docker Compose. This requires you to have Selenium running locally on your computer. When running in a local environment you do not need to include the selenium-hub environment variable. Instead, you must choose whichever browser you have set up locally:
+
+`codecept run acceptance --env selenium-chrome`
+
+
+==== Using Docker Compose with the Selenium Hub
+
+In your selenium development environment it is recommended that you employ docker compose to set up a selenium hub with a selenium node. This will ensure your version of Chrome or Firefox is kept up-to-date with the latest version. In addition, you can also run multiple versions of PHP on the same host machine.
+
+You can configure selenium using docker compose. Please ensure you have the following in your docker-compose.yml file.
+
+[source,docker]
+version: '3'
+services:
+    selenium-hub:
+      image: selenium/hub
+      restart: always
+      ports:
+        - 4444:4444
+    selenium-node-chrome:
+      image: selenium/node-chrome-debug
+      restart: always
+      ports:
+        - 5900:5900
+      links:
+        - selenium-hub:hub
+      environment:
+              - "HUB_PORT_4444_TCP_ADDR=selenium-hub"
+              - "HUB_PORT_4444_TCP_PORT=4444"
+    selenium-node-firefox:
+      image: selenium/node-firefox-debug
+      restart: always
+      ports:
+        - 5901:5900
+      links:
+        - selenium-hub:hub
+      environment:
+              - "HUB_PORT_4444_TCP_ADDR=selenium-hub"
+              - "HUB_PORT_4444_TCP_PORT=4444"
+
+*Note: you can also choose different images for the nodes, for example the nodes without vnc support*
+
+
+==== Screen Resolutions / Fake Devices
+
+Here are the different configurations for each target device we test for:
+
+[width="80",cols="60,20",options="header",]
+|=======================================================================
+| Device            | Resolution
+
+| selenium-iphone-6 | 375x667
+| selenium-ipad-2   | 768x1024
+| selenium-xga      | 1024x768
+| selenium-hd       | 1280x720
+| selenium-fhd      | 1920x1080
+|=======================================================================
+
+==== Run Selenium Hub
+
+`codecept run acceptance --env selenium-hub,selenium-xga`
+
+*Please note:* that the SuiteCRM automated test framework uses *height* and *width* values to define the window size instead of the window_size. window_size is ignored by the automated test framework.
+
+
+==== Selecting Browser
+
+You can select the browser you wish to test by adding it to the --env.
+
+`codecept run acceptance --env selenium-hub,selenium-chrome`
+
+or
+
+`codecept run acceptance --env selenium-hub,selenium-firefox`
+


### PR DESCRIPTION
- Miscellaneous wording/punctuation improvements to the automated testing setup docs.
- Create an automated testing directory
- Split 'Writing Tests' into a separate file to simplify the main automated testing documentation.
- Move `TestingEnvironment` to the Automated Testing directory.