### PR TITLE
Missing "generate_select" => true,

### DIFF
--- a/content/developer/Appendix A - Code Examples.adoc
+++ b/content/developer/Appendix A - Code Examples.adoc
@@ -31,6 +31,7 @@ $layout_defs["Cases"]["subpanel_setup"]['incident_cases'] = array(
    'get_subpanel_data' => 'function:get_cases_by_incident',
    'function_parameters' => 
            array('import_function_file' => 'custom/modules/Cases/IncidentUtils.php',),
+           "generate_select" => true,
 );
 ----
 


### PR DESCRIPTION
Without this value the sugarbean class will be expecting a string instead of an array and since the custom/modules/Cases/IncidentUtils.php returns an array it won't work without this directive