### PR TITLE
Fixed broken link to v8 API

### DIFF
--- a/content/developer/api/API-4_1.adoc
+++ b/content/developer/api/API-4_1.adoc
@@ -8,7 +8,7 @@ title: "API v4.1"
 
 {{% notice warning %}}
 This documentation pertains to SuiteCRM versions up to v.7.9.x. 
-Since SuiteCRM version 7.10, a link:../version-8[brand new v8 REST API] is available.
+Since SuiteCRM version 7.10, a link:../[brand new v8 REST API] is available.
 {{% /notice %}}
 
 The SuiteCRM API allows third party code to access and edit SuiteCRM


### PR DESCRIPTION
The old version-8 page is a combination of both developer-setup-guide and postman-setup-guide page so I linked to main API page.

https://github.com/salesagility/SuiteDocs/issues/355