### PR TITLE
Fixed DoS vulnerability (CVE-2018-18385)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@
 source "https://rubygems.org"
 
 # gem "rails"
-gem 'asciidoctor'
+gem "asciidoctor", "~> 1.5.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    asciidoctor (1.5.6.1)
+    asciidoctor (1.5.8.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Found a vulnerability that would allow DoS.
**Introduced through**: `salesagility/SuiteDocs@salesagility/SuiteDocs#062c2502c603572545813b2e0aabf884d87671ff › asciidoctor@1.5.6.1 `

The version of `asciidoctor` that you had is vulnerable to Denial of Service (DoS) attacks via the `next_block` method. The current pull request solves the vulnerability.


Reference to this vulnerability:
https://github.com/asciidoctor/asciidoctor/commit/643f0cf860992147cf9f26586a8633ee294886a5
https://github.com/asciidoctor/asciidoctor/issues/2888