### PR TITLE
Fix incorrect instruction on indexing section

### DIFF
--- a/content/admin/administration-panel/search/elasticsearch/Command Line Tools.adoc
+++ b/content/admin/administration-panel/search/elasticsearch/Command Line Tools.adoc
@@ -33,11 +33,11 @@ elastic:index [<differential> = 1]
 
 Running a full indexing:
 [source,bash]
-vendor/bin/robo elastic:index 1
+vendor/bin/robo elastic:index 0
 
 Running a partial indexing:
 [source,bash]
-vendor/bin/robo elastic:index 0
+vendor/bin/robo elastic:index 1
 
 image:ElasticIndexCLI.png["Elasticsearch Index CLI"]
 


### PR DESCRIPTION
Full index value on robo is 0, and partial is 1.