### PR TITLE
Use Shortcodes instead of "pass:" direct HTML hacks

### DIFF
--- a/content/admin/Advanced Configuration Options.adoc
+++ b/content/admin/Advanced Configuration Options.adoc
@@ -54,7 +54,7 @@ For import, export, synchronization, and when working in the administration pane
 the maximum number of requests is 50,000. Thus, all processes that take up too
 much system resources are interrupted. You can change these settings as
 desired by specifying values ​​for variables
-`defaultpass:[_]limit` and `specialpass:[_]querypass:[_]limit` in file `config.php`.
+`default_limit` and `special_query_limit` in file `config.php`.
 
 == Setting file system permissions in Linux
 
@@ -71,15 +71,15 @@ The following example shows the read, write and execute permissions for the user
 'chown' => 'apache',
 'chgrp' => 'apache',),
 
-For the parameter `dirpass:[_]mode` you can set the value to ```1528```,
+For the parameter `dir_mode` you can set the value to ```1528```,
 which is the decimal equivalent of the octal value ```02770```. For the parameter
-`filepass:[_]mode` you can set the value to ```432```, which is the decimal equivalent of the octal value ```0660```.
+`file_mode` you can set the value to ```432```, which is the decimal equivalent of the octal value ```0660```.
 
 == Changing the location of the download folder
 
 All files downloaded by the system are stored in a special download folder. Its location is set by variable
-`uploadpass:[_]dir` in file `config.php`. By default, this is the upload folder, located in the installed system folder.
-If necessary, its location can be changed, for this purpose in a variable `uploadpass:[_]dir` set the absolute
+`upload_dir` in file `config.php`. By default, this is the upload folder, located in the installed system folder.
+If necessary, its location can be changed, for this purpose in a variable `upload_dir` set the absolute
 path to the new location of the download folder.
 
 {{% notice note %}}
@@ -94,7 +94,7 @@ The system actively uses data caching, which greatly improves its performance.
 A special folder is used to store cached data (compiled templates, email data, etc.)
 and its size can be quite large. By default, this is the cache folder located in the installed system folder.
 If necessary, its location can be changed, for this purpose in a variable
-`cachepass:[_]dir`, located in the file `config.php`, set the absolute path to the new
+`cache_dir`, located in the file `config.php`, set the absolute path to the new
 location of the cache folder. At the same time, the link pointing to the new cache
 folder should be placed in the same place of the cache folder.
 This is necessary to provide access to some cached system files.

--- a/content/admin/releases/7.10.x/_index.en.adoc
+++ b/content/admin/releases/7.10.x/_index.en.adoc
@@ -131,15 +131,7 @@ use Psr\Container\ContainerInterface;
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/re8260.png" data-featherlight="image"><img src="https://github.com/re8260.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/re8260" class="highlight">re8260</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/connorshea.png" data-featherlight="image"><img src="https://github.com/connorshea.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/connorshea" class="highlight">connorshea</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/marin-h.png" data-featherlight="image"><img src="https://github.com/marin-h.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/marin-h" class="highlight">marin-h</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/ebogaard.png" data-featherlight="image"><img src="https://github.com/ebogaard.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/ebogaard" class="highlight">ebogaard</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/lazka.png" data-featherlight="image"><img src="https://github.com/lazka.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/lazka" class="highlight">lazka</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/crgrieve.png" data-featherlight="image"><img src="https://github.com/crgrieve.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/crgrieve" class="highlight">crgrieve</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/Abuelodelanada.png" data-featherlight="image"><img src="https://github.com/Abuelodelanada.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/Abuelodelanada" class="highlight">Abuelodelanada</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/dominicchinkh.png" data-featherlight="image"><img src="https://github.com/dominicchinkh.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/dominicchinkh" class="highlight">dominicchinkh</a></div>]
-pass:[<div style="float:clear; margin-right:10px;"><a href="https://github.com/kichloo.png" data-featherlight="image"><img src="https://github.com/kichloo.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/kichloo" class="highlight">kichloo</a></div>]
+{{% ghcontributors re8260 connorshea marin-h ebogaard lazka crgrieve Abuelodelanada dominicchinkh kichloo %}}
 
 Please https://suitecrm.com/download[visit the official website] to find the appropriate upgrade package.
 
@@ -349,27 +341,7 @@ _Released 04/11/2019_
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/connorshea.png" data-featherlight="image"><img src="https://github.com/connorshea.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/connorshea" class="highlight">connorshea</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/604media.png" data-featherlight="image"><img src="https://github.com/604media.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/604media" class="highlight">604media</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/tsummerer.png" data-featherlight="image"><img src="https://github.com/tsummerer.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/tsummerer" class="highlight">tsummerer</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/re8260.png" data-featherlight="image"><img src="https://github.com/re8260.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/re8260" class="highlight">re8260</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/lazka.png" data-featherlight="image"><img src="https://github.com/lazka.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/lazka" class="highlight">lazka</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/Abuelodelanada.png" data-featherlight="image"><img src="https://github.com/Abuelodelanada.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/Abuelodelanada" class="highlight">Abuelodelanada</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/dominicchinkh.png" data-featherlight="image"><img src="https://github.com/dominicchinkh.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/dominicchinkh" class="highlight">dominicchinkh</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/JanSiero.png" data-featherlight="image"><img src="https://github.com/JanSiero.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/JanSiero" class="highlight">JanSiero</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/QuickCRM.png" data-featherlight="image"><img src="https://github.com/QuickCRM.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/QuickCRM" class="highlight">QuickCRM</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/HVStechnik.png" data-featherlight="image"><img src="https://github.com/HVStechnik.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/HVStechnik" class="highlight">HVStechnik</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/lex111.png" data-featherlight="image"><img src="https://github.com/lex111.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/lex111" class="highlight">lex111</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/Kishlin.png" data-featherlight="image"><img src="https://github.com/Kishlin.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/Kishlin" class="highlight">Kishlin</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/ognjen-petrovic.png" data-featherlight="image"><img src="https://github.com/ognjen-petrovic.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/ognjen-petrovic" class="highlight">ognjen-petrovic</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/ApatheticCosmos.png" data-featherlight="image"><img src="https://github.com/ApatheticCosmos.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/ApatheticCosmos" class="highlight">ApatheticCosmos</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/akshitsarin.png" data-featherlight="image"><img src="https://github.com/akshitsarin.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/akshitsarin" class="highlight">akshitsarin</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/grahambrown11.png" data-featherlight="image"><img src="https://github.com/grahambrown11.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/grahambrown11" class="highlight">grahambrown11</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/00MB.png" data-featherlight="image"><img src="https://github.com/00MB.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/00MB" class="highlight">00MB</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/IvanArjona.png" data-featherlight="image"><img src="https://github.com/IvanArjona.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/IvanArjona" class="highlight">IvanArjona</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/ozdemirburak.png" data-featherlight="image"><img src="https://github.com/ozdemirburak.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/ozdemirburak" class="highlight">ozdemirburak</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/mirajkovic.png" data-featherlight="image"><img src="https://github.com/mirajkovic.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/mirajkovic" class="highlight">mirajkovic</a></div>]
-pass:[<div style="float:clear; margin-right:10px;"><a href="https://github.com/steffinstanly.png" data-featherlight="image"><img src="https://github.com/steffinstanly.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/steffinstanly" class="highlight">steffinstanly</a></div>]
+{{% ghcontributors connorshea 604media tsummerer re8260 lazka Abuelodelanada dominicchinkh JanSiero QuickCRM HVStechnik lex111 Kishlin ognjen-petrovic ApatheticCosmos akshitsarin grahambrown11 00MB IvanArjona ozdemirburak mirajkovic steffinstanly %}}
 
 Please https://suitecrm.com/download[visit the official website] to find the appropriate upgrade package.
 
@@ -442,11 +414,7 @@ Plugin files are still usable in the same way as before – at `./include/Smarty
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/JanSiero.png" data-featherlight="image"><img src="https://github.com/JanSiero.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/JanSiero" class="highlight">JanSiero</a></div>]
-
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/604media.png" data-featherlight="image"><img src="https://github.com/604media.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/604media" class="highlight">604media</a></div>]
-
-pass:[<div style="float:clear; margin-right:10px;"><a href="https://github.com/connorshea.png" data-featherlight="image"><img src="https://github.com/connorshea.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/connorshea" class="highlight">connorshea</a></div>]
+{{% ghcontributors JanSiero 604media connorshea %}}
 
 '''
 
@@ -541,25 +509,7 @@ _Released 31st July 2019_
 
 _Special thanks to all members for their contributions and participation in this release!_
 
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/connorshea.png" data-featherlight="image"><img src="https://github.com/connorshea.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/connorshea" class="highlight">connorshea</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/lazka.png" data-featherlight="image"><img src="https://github.com/lazka.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/lazka" class="highlight">lazka</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/604media.png" data-featherlight="image"><img src="https://github.com/604media.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/604media" class="highlight">604media</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/marin-h.png" data-featherlight="image"><img src="https://github.com/marin-h.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/marin-h" class="highlight">marin-h</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/gody01.png" data-featherlight="image"><img src="https://github.com/gody01.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/gody01" class="highlight">gody01</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/Abuelodelanada.png" data-featherlight="image"><img src="https://github.com/Abuelodelanada.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/Abuelodelanada" class="highlight">Abuelodelanada</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/eggsurplus.png" data-featherlight="image"><img src="https://github.com/eggsurplus.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/eggsurplus" class="highlight">eggsurplus</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/sanchezfauste.png" data-featherlight="image"><img src="https://github.com/sanchezfauste.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/sanchezfauste" class="highlight">sanchezfauste</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/adriangibanelbtactic.png" data-featherlight="image"><img src="https://github.com/adriangibanelbtactic.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/adriangibanelbtactic" class="highlight">adriangibanelbtactic</a></div>]
-
-pass:[<div style="float:clear;margin-right:10px;"><a href="https://github.com/ebogaard.png" data-featherlight="image"><img src="https://github.com/ebogaard.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/ebogaard" class="highlight">ebogaard</a></div>]
+{{% ghcontributors connorshea lazka 604media marin-h gody01 Abuelodelanada eggsurplus sanchezfauste adriangibanelbtactic ebogaard %}}
 
 '''
 
@@ -1034,15 +984,9 @@ Please https://suitecrm.com/download[visit the official website] to find the app
 
 [[anchor-7.10.11-community]]
 
-_Special thanks to the following members for their contributions!_
+_Special thanks to LEAP-nishit and the following members for their contributions!_
 
-* https://github.com/gunnicom[gunnicom]
-* https://github.com/LEAP-nishit[LEAP-nishit]
-* https://github.com/lazka[lazka]
-* https://github.com/rediansoftware[rediansoftware]
-* https://github.com/QuickCRM[QuickCRM]
-* https://github.com/AussieGuy0[AussieGuy0]
-* https://github.com/apoonawa[apoonawa]
+{{% ghcontributors gunnicom lazka rediansoftware QuickCRM AussieGuy0 apoonawa %}}
 
 That's a total of **12 community merges** across the releases! Well done everyone!
 
@@ -1916,4 +1860,5 @@ code* (tar.gz)]
 *This is a Beta release and should not be used in a production environment.*
 
 '''
+
 

--- a/content/admin/releases/7.10.x/_index.en.adoc
+++ b/content/admin/releases/7.10.x/_index.en.adoc
@@ -6,27 +6,26 @@ weight: 9890
 :toc:
 :toc-title:
 :toclevels: 1
-
-:experimental:
+:icons: font
 
 == 7.10.23
 
 _Released 10/02/2020_
 
-=== pass:[<i class="fa fa-files-o fa-1x"></i>] Assets
+=== icon:box-open[] Assets
 
 * https://github.com/salesagility/SuiteCRM/archive/v7.10.23.zip[*Source code* (zip)]
 * https://github.com/salesagility/SuiteCRM/archive/v7.10.23.tar.gz[*Source code* (tar.gz)]
 
 [discrete]
 
-==== pass:[<i class="fa fa-clipboard fa-1x"></i>] Administrators Note 1/2
+==== icon:clipboard[] Administrators Note 1/2
 You may notice when installing SuiteCRM a new panel which allows for the configuration of different collations and type-sets. This is part of our progression towards resolving issues with special characters and emojis. Currently available sets include utf8 and utf8mb4.
 
-==== pass:[<i class="fa fa-clipboard fa-1x"></i>] Administrators Note 2/2
+==== icon:clipboard[] Administrators Note 2/2
 Within this release, we have also resolved a few known issues with the upgrade process; however, they will unfortunately not take effect until the next upgrade cycle. Therefore it is vital that if you encounter any problems while installing that you review and follow the recommended process within the SuiteDocs upgrade debugging page which can be found https://community.suitecrm.com/t/debugging-steps-for-use-in-upgrade-version-prior-to-7-11-11-and-7-10-23/71273[here]
 
-==== pass:[<i class="fa fa-wrench fa-1x"></i>] Potential breaking change with package container-interop
+==== icon:wrench[] Potential breaking change with package container-interop
 If you maintain a CRM utilising container-interop for API extension, you should note that this release may require some small changes to routing as seen below:
 
 Instead of `Interop`
@@ -39,9 +38,9 @@ use Psr\Container\ContainerInterface;
 ```
 [discrete]
 
-===  pass:[<i class="fa fa-check fa-1x"></i>] Release Notes
+===  icon:check[] Release Notes
 
-==== pass:[<i class="fa fa-lock fa-1x"></i>] Security
+==== icon:lock[] Security
 
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8787[CVE-2020-8787^] - Bean ID validation strictness
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8783[CVE-2020-8783^] - Neutralization of potential vulnerability with use of Special Elements within SQL
@@ -51,7 +50,7 @@ use Psr\Container\ContainerInterface;
 
 [discrete]
 
-==== pass:[<i class="fa fa-star-o fa-1x"></i>] Enhancements
+==== icon:star[] Enhancements
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8100[8100^] - Issue: https://github.com/salesagility/SuiteCRM/issues/8099[8099^] - Add a way to hide/show columnChooser in ListViews
 * PR: https://github.com/salesagility/SuiteCRM/pull/7879[7879^] - Issue: https://github.com/salesagility/SuiteCRM/issues/7876[7876^] - Render phone fields as links
@@ -62,7 +61,7 @@ use Psr\Container\ContainerInterface;
 
 [discrete]
 
-==== pass:[<i class="fa fa-bug fa-1x"></i>] Bug Fixes
+==== icon:bug[] Bug Fixes
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8422[8422^] - Issue: https://github.com/salesagility/SuiteCRM/issues/8421[8421^] - Fix issue with validation on aos settings
 * PR: https://github.com/salesagility/SuiteCRM/pull/8395[8395^] - Issue: https://github.com/salesagility/SuiteCRM/issues/6000[6000^] - Notifications not working when using mssql
@@ -95,7 +94,7 @@ use Psr\Container\ContainerInterface;
 * PR: https://github.com/salesagility/SuiteCRM/pull/8326[8326^] - Logo upload
 [discrete]
 
-==== pass:[<i class="fa fa-code-fork fa-1x"></i>] Development
+==== icon:code-branch[] Development
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8231[8231^] - Issue: https://github.com/salesagility/SuiteCRM/issues/7891[7891^] - Clean up include/ tests
 * PR: https://github.com/salesagility/SuiteCRM/pull/8218[8218^] - Issue: https://github.com/salesagility/SuiteCRM/issues/7744[7744^] - Remove deprecated functions from utils.php
@@ -128,7 +127,7 @@ use Psr\Container\ContainerInterface;
 * PR: https://github.com/salesagility/SuiteCRM/pull/8161[8161^] - Fix a PHP warning in Meeting.php
 [discrete]
 
-=== pass:[<i class="fa fa-heart fa-1x"></i>] Community
+=== icon:heart[] Community
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
@@ -152,18 +151,18 @@ To report any security issues please follow our Security Process and send them d
 
 _Released 11/11/2019_
 
-=== pass:[<i class="fa fa-files-o fa-1x"></i>] Assets
+=== icon:box-open[] Assets
 
 * https://github.com/salesagility/SuiteCRM/archive/v7.10.22.zip[*Source code* (zip)]
 * https://github.com/salesagility/SuiteCRM/archive/v7.10.22.tar.gz[*Source code* (tar.gz)]
 
-===  pass:[<i class="fa fa-check fa-1x"></i>] Release Notes
+===  icon:check[] Release Notes
 
-==== pass:[<i class="fa fa-lock fa-1x"></i>] Security
+==== icon:lock[] Security
 
 * CVE: Unassigned - SQL Injection
 
-==== pass:[<i class="fa fa-bug fa-1x"></i>] Bug Fixes
+==== icon:bug[] Bug Fixes
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8185[8185^] - Issue: https://github.com/salesagility/SuiteCRM/issues/7946[7946^] - Removed unnecessary JSSource files
 * PR: https://github.com/salesagility/SuiteCRM/pull/8187[8187^] - Issue: https://github.com/salesagility/SuiteCRM/issues/8183[8183^] - non-group records show on list view if group only access
@@ -182,21 +181,21 @@ To report any security issues please follow our Security Process and send them d
 
 _Released 04/11/2019_
 
-=== pass:[<i class="fa fa-files-o fa-1x"></i>] Assets
+=== icon:box-open[] Assets
 
 * https://github.com/salesagility/SuiteCRM/archive/v7.10.21.zip[*Source code* (zip)]
 * https://github.com/salesagility/SuiteCRM/archive/v7.10.21.tar.gz[*Source code* (tar.gz)]
 
-===  pass:[<i class="fa fa-check fa-1x"></i>] Release Notes
+===  icon:check[] Release Notes
 
-==== pass:[<i class="fa fa-lock fa-1x"></i>] Security
+==== icon:lock[] Security
 
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18782[CVE-2019-18782^] - .htaccess Improvements
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18785[CVE-2019-18785^] - API Access Token and Credential fix
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18784[CVE-2019-18784^] - Neutralization of potential vulnerability with use of Special Elements within SQL
 [discrete]
 
-==== pass:[<i class="fa fa-star-o fa-1x"></i>] Enhancements
+==== icon:star[] Enhancements
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/7198[7198^] - Add Robo API commands
 * PR: https://github.com/salesagility/SuiteCRM/pull/5464[5464^] - Filter email templates on Events
@@ -210,7 +209,7 @@ _Released 04/11/2019_
 
 [discrete]
 
-==== pass:[<i class="fa fa-bug fa-1x"></i>] Bug Fixes
+==== icon:bug[] Bug Fixes
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8154[8154^] - Issue: https://github.com/salesagility/SuiteCRM/issues/8153[8153^] - SQL query in the ACLAction code
 * PR: https://github.com/salesagility/SuiteCRM/pull/8151[8151^] - Resolve issue with email templates
@@ -337,7 +336,7 @@ _Released 04/11/2019_
 
 [discrete]
 
-==== pass:[<i class="fa fa-code-fork fa-1x"></i>] Development
+==== icon:code-branch[] Development
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8000[8000^] - More PHP 7.4 array accessor deprecations
 * PR: https://github.com/salesagility/SuiteCRM/pull/6750[6750^] - Issue: https://github.com/salesagility/SuiteCRM/issues/4754[4754^] - Remove PHP4 style constructors
@@ -346,7 +345,7 @@ _Released 04/11/2019_
 
 [discrete]
 
-=== pass:[<i class="fa fa-heart fa-1x"></i>] Community
+=== icon:heart[] Community
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
@@ -383,21 +382,21 @@ To report any security issues please follow our Security Process and send them d
 
 _Released 23/08/2019_
 
-=== pass:[<i class="fa fa-files-o fa-1x"></i>] Assets
+=== icon:box-open[] Assets
 
 * https://github.com/salesagility/SuiteCRM/archive/v7.10.20.zip[*Source code* (zip)]
 * https://github.com/salesagility/SuiteCRM/archive/v7.10.20.tar.gz[*Source code* (tar.gz)]
 
-===  pass:[<i class="fa fa-check fa-1x"></i>] Release Notes
+===  icon:check[] Release Notes
 
-==== pass:[<i class="fa fa-lock fa-1x"></i>] Security
+==== icon:lock[] Security
 
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14752[CVE-2019-14752^] - Reflected XSS
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18783[CVE-2019-18783^] - Unintended public exposure of files
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14454[CVE-2019-14454^] - Employee module does not implement ACL
 [discrete]
 
-==== pass:[<i class="fa fa-star-o fa-1x"></i>] Enhancements
+==== icon:star[] Enhancements
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/7702[7702 ] - Issue: https://github.com/salesagility/SuiteCRM/issues/7696[7696 ] - Update README
 * PR: https://github.com/salesagility/SuiteCRM/pull/7698[7698 ] - Issue: https://github.com/salesagility/SuiteCRM/issues/7581[7581 ] - SuiteBot config.yml
@@ -424,7 +423,7 @@ Plugin files are still usable in the same way as before – at `./include/Smarty
 
 [discrete]
 
-==== pass:[<i class="fa fa-bug fa-1x"></i>] Bug Fixes
+==== icon:bug[] Bug Fixes
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/7719[7719 ] - Fix/backwards compatibility
 * PR: https://github.com/salesagility/SuiteCRM/pull/7718[7718 ] - Issue: https://github.com/salesagility/SuiteCRM/issues/6982[6982 ] - New user password not being generated
@@ -439,7 +438,7 @@ Plugin files are still usable in the same way as before – at `./include/Smarty
 * PR: https://github.com/salesagility/SuiteCRM/pull/7610[7610 ] - Fixed error message css + email warning config option
 [discrete]
 
-=== pass:[<i class="fa fa-heart fa-1x"></i>] Community
+=== icon:heart[] Community
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
@@ -461,27 +460,27 @@ To report any security issues please follow our Security Process and send them d
 
 _Released 31st July 2019_
 
-=== pass:[<i class="fa fa-files-o fa-1x"></i>] Assets
+=== icon:box-open[] Assets
 
 * https://github.com/salesagility/SuiteCRM/archive/v7.10.19.zip[*Source code* (zip)]
 * https://github.com/salesagility/SuiteCRM/archive/v7.10.19.tar.gz[*Source code* (tar.gz)]
 
-===  pass:[<i class="fa fa-check fa-1x"></i>] Release Notes
+===  icon:check[] Release Notes
 
-==== pass:[<i class="fa fa-lock fa-1x"></i>] Security
+==== icon:lock[] Security
 
 [discrete]
 
 * https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-13335[#CVE-2019-13335 ] - *Security Issue* - Fixed SSRF
 * *Security Issue* - Fixed privilege escalation
 
-==== pass:[<i class="fa fa-star-o fa-1x"></i>] Enhancements 
+==== icon:star[] Enhancements 
 
 * https://github.com/salesagility/SuiteCRM/pull/7374[#7374 ] Robo test-running commands
 * https://github.com/salesagility/SuiteCRM/pull/7474[#7474 ] SecuritySuite 3.1.16
 * https://github.com/salesagility/SuiteCRM/pull/7503[#7503 ] Scheduled Reports: Enable security groups support and add the subpanel
 
-==== pass:[<i class="fa fa-bug fa-1x"></i>] Bug Fixes
+==== icon:bug[] Bug Fixes
 
 * https://github.com/salesagility/SuiteCRM/issues/3756[#3756 ] Fixed #3756 - Calendar pop-ups now auto close after 500ms
 * https://github.com/salesagility/SuiteCRM/pull/6850[#6850 ] SAML2: Use php-saml from composer
@@ -538,7 +537,7 @@ _Released 31st July 2019_
 * https://github.com/salesagility/SuiteCRM/issues/6996[#6996 ] Escaped strings issue, breaks "My favorites" filters and perhaps other things
 * https://github.com/salesagility/SuiteCRM/pull/7639[#7639 ] Fixed DB failure with activities subpanel
 
-=== pass:[<i class="fa fa-heart fa-1x"></i>] Community
+=== icon:heart[] Community
 
 _Special thanks to all members for their contributions and participation in this release!_
 
@@ -1917,3 +1916,4 @@ code* (tar.gz)]
 *This is a Beta release and should not be used in a production environment.*
 
 '''
+

--- a/content/admin/releases/7.11.x/_index.en.adoc
+++ b/content/admin/releases/7.11.x/_index.en.adoc
@@ -57,7 +57,7 @@ use Psr\Container\ContainerInterface;
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8100[8100^] - Issue: https://github.com/salesagility/SuiteCRM/issues/8099[8099^] - Add a way to hide/show columnChooser in ListViews
 * PR: https://github.com/salesagility/SuiteCRM/pull/7879[7879^] - Issue: https://github.com/salesagility/SuiteCRM/issues/7876[7876^] - Render phone fields as links
-* PR: https://github.com/salesagility/SuiteCRM/pull/8215[8215^] - Scroll QRFont colour is the same as the search bar bgR to see the 'sync with vardefs' part
+* PR: https://github.com/salesagility/SuiteCRM/pull/8215[8215^] - Scroll QR&R to see the 'sync with vardefs' part
 * PR: https://github.com/salesagility/SuiteCRM/pull/8164[8164^] - More inclusive language
 * PR: https://github.com/salesagility/SuiteCRM/pull/8160[8160^] - Updated CONTRIBUTING.md
 * PR: https://github.com/salesagility/SuiteCRM/pull/7798[7798^] - Database character set configuration
@@ -135,15 +135,7 @@ use Psr\Container\ContainerInterface;
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/re8260.png" data-featherlight="image"><img src="https://github.com/re8260.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/re8260" class="highlight">re8260</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/connorshea.png" data-featherlight="image"><img src="https://github.com/connorshea.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/connorshea" class="highlight">connorshea</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/marin-h.png" data-featherlight="image"><img src="https://github.com/marin-h.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/marin-h" class="highlight">marin-h</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/ebogaard.png" data-featherlight="image"><img src="https://github.com/ebogaard.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/ebogaard" class="highlight">ebogaard</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/lazka.png" data-featherlight="image"><img src="https://github.com/lazka.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/lazka" class="highlight">lazka</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/crgrieve.png" data-featherlight="image"><img src="https://github.com/crgrieve.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/crgrieve" class="highlight">crgrieve</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/Abuelodelanada.png" data-featherlight="image"><img src="https://github.com/Abuelodelanada.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/Abuelodelanada" class="highlight">Abuelodelanada</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/dominicchinkh.png" data-featherlight="image"><img src="https://github.com/dominicchinkh.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/dominicchinkh" class="highlight">dominicchinkh</a></div>]
-pass:[<div style="float:clear; margin-right:10px;"><a href="https://github.com/kichloo.png" data-featherlight="image"><img src="https://github.com/kichloo.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/kichloo" class="highlight">kichloo</a></div>]
+{{% ghcontributors re8260 connorshea marin-h ebogaard lazka crgrieve Abuelodelanada dominicchinkh kichloo %}}
 
 Please https://suitecrm.com/download[visit the official website] to find the appropriate upgrade package.
 
@@ -359,27 +351,7 @@ _Released 04/11/2019_
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/connorshea.png" data-featherlight="image"><img src="https://github.com/connorshea.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/connorshea" class="highlight">connorshea</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/604media.png" data-featherlight="image"><img src="https://github.com/604media.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/604media" class="highlight">604media</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/tsummerer.png" data-featherlight="image"><img src="https://github.com/tsummerer.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/tsummerer" class="highlight">tsummerer</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/re8260.png" data-featherlight="image"><img src="https://github.com/re8260.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/re8260" class="highlight">re8260</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/lazka.png" data-featherlight="image"><img src="https://github.com/lazka.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/lazka" class="highlight">lazka</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/Abuelodelanada.png" data-featherlight="image"><img src="https://github.com/Abuelodelanada.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/Abuelodelanada" class="highlight">Abuelodelanada</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/dominicchinkh.png" data-featherlight="image"><img src="https://github.com/dominicchinkh.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/dominicchinkh" class="highlight">dominicchinkh</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/JanSiero.png" data-featherlight="image"><img src="https://github.com/JanSiero.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/JanSiero" class="highlight">JanSiero</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/QuickCRM.png" data-featherlight="image"><img src="https://github.com/QuickCRM.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/QuickCRM" class="highlight">QuickCRM</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/HVStechnik.png" data-featherlight="image"><img src="https://github.com/HVStechnik.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/HVStechnik" class="highlight">HVStechnik</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/lex111.png" data-featherlight="image"><img src="https://github.com/lex111.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/lex111" class="highlight">lex111</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/Kishlin.png" data-featherlight="image"><img src="https://github.com/Kishlin.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/Kishlin" class="highlight">Kishlin</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/ognjen-petrovic.png" data-featherlight="image"><img src="https://github.com/ognjen-petrovic.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/ognjen-petrovic" class="highlight">ognjen-petrovic</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/ApatheticCosmos.png" data-featherlight="image"><img src="https://github.com/ApatheticCosmos.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/ApatheticCosmos" class="highlight">ApatheticCosmos</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/akshitsarin.png" data-featherlight="image"><img src="https://github.com/akshitsarin.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/akshitsarin" class="highlight">akshitsarin</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/grahambrown11.png" data-featherlight="image"><img src="https://github.com/grahambrown11.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/grahambrown11" class="highlight">grahambrown11</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/00MB.png" data-featherlight="image"><img src="https://github.com/00MB.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/00MB" class="highlight">00MB</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/IvanArjona.png" data-featherlight="image"><img src="https://github.com/IvanArjona.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/IvanArjona" class="highlight">IvanArjona</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/ozdemirburak.png" data-featherlight="image"><img src="https://github.com/ozdemirburak.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/ozdemirburak" class="highlight">ozdemirburak</a></div>]
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/mirajkovic.png" data-featherlight="image"><img src="https://github.com/mirajkovic.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/mirajkovic" class="highlight">mirajkovic</a></div>]
-pass:[<div style="float:clear; margin-right:10px;"><a href="https://github.com/steffinstanly.png" data-featherlight="image"><img src="https://github.com/steffinstanly.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/steffinstanly" class="highlight">steffinstanly</a></div>]
+{{% ghcontributors connorshea 604media tsummerer re8260 lazka Abuelodelanada dominicchinkh JanSiero QuickCRM HVStechnik lex111 Kishlin ognjen-petrovic ApatheticCosmos akshitsarin grahambrown11 00MB IvanArjona ozdemirburak mirajkovic steffinstanly %}}
 
 Please https://suitecrm.com/download[visit the official website] to find the appropriate upgrade package.
 
@@ -451,11 +423,7 @@ Plugin files are still usable in the same way as before – at `./include/Smarty
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/JanSiero.png" data-featherlight="image"><img src="https://github.com/JanSiero.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/JanSiero" class="highlight">JanSiero</a></div>]
-
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/604media.png" data-featherlight="image"><img src="https://github.com/604media.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/604media" class="highlight">604media</a></div>]
-
-pass:[<div style="float:clear; margin-right:10px;"><a href="https://github.com/connorshea.png" data-featherlight="image"><img src="https://github.com/connorshea.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/connorshea" class="highlight">connorshea</a></div>]
+{{% ghcontributors JanSiero 604media connorshea %}}
 
 '''
 
@@ -549,25 +517,7 @@ _Released 31st July 2019_
 
 _Special thanks to all members for their contributions and participation in this release!_
 
-pass:[<div style="float:left; margin-right:10px;"><a href="https://github.com/connorshea.png" data-featherlight="image"><img src="https://github.com/connorshea.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/connorshea" class="highlight">connorshea</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/lazka.png" data-featherlight="image"><img src="https://github.com/lazka.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/lazka" class="highlight">lazka</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/604media.png" data-featherlight="image"><img src="https://github.com/604media.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/604media" class="highlight">604media</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/marin-h.png" data-featherlight="image"><img src="https://github.com/marin-h.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/marin-h" class="highlight">marin-h</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/gody01.png" data-featherlight="image"><img src="https://github.com/gody01.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/gody01" class="highlight">gody01</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/Abuelodelanada.png" data-featherlight="image"><img src="https://github.com/Abuelodelanada.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/Abuelodelanada" class="highlight">Abuelodelanada</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/eggsurplus.png" data-featherlight="image"><img src="https://github.com/eggsurplus.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/eggsurplus" class="highlight">eggsurplus</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/sanchezfauste.png" data-featherlight="image"><img src="https://github.com/sanchezfauste.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/sanchezfauste" class="highlight">sanchezfauste</a></div>]
-
-pass:[<div style="float:left;margin-right:10px;"><a href="https://github.com/adriangibanelbtactic.png" data-featherlight="image"><img src="https://github.com/adriangibanelbtactic.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/adriangibanelbtactic" class="highlight">adriangibanelbtactic</a></div>]
-
-pass:[<div style="float:clear;margin-right:10px;"><a href="https://github.com/ebogaard.png" data-featherlight="image"><img src="https://github.com/ebogaard.png" alt="SuiteCRM Contributor" style="margin:0px;" width="50" height="50"></a><a href="https://github.com/ebogaard" class="highlight">ebogaard</a></div>]
+{{% ghcontributors connorshea lazka 604media marin-h gody01 Abuelodelanada eggsurplus sanchezfauste adriangibanelbtactic ebogaard %}}
 
 '''
 
@@ -1142,23 +1092,10 @@ In total, we have merged a **MASSIVE 69 PULL REQUESTS** with **24** of these fro
 {{% /notice %}}
 
 
-Special thanks to the following members for their contributions and participation in this release
+Special thanks to LEAP-nishit and the following members for their contributions and participation in this release
 (in order of most Pull Requests contributed). +
 
-. https://github.com/lazka[lazka]
-. https://github.com/Abuelodelanada[Abuelodelanada]
-. https://github.com/urdhvatech[urdhvatech]
-. https://github.com/gmblake[gmblake]
-. https://github.com/machinecha[machinecha]
-. https://github.com/GFanta[GFanta]
-. https://github.com/Jorilx[Jorilx]
-. https://github.com/QuickCRM[QuickCRM]
-. https://github.com/connorshea[connorshea]
-. https://github.com/LionelBino[LionelBino]
-. https://github.com/hieuhoanghd[hieuhoanghd]
-. https://github.com/jsamelko[jsamelko]
-. https://github.com/LEAP-nishit[LEAP-nishit] +
-
+{{% ghcontributors lazka Abuelodelanada urdhvatech gmblake machinecha g-fantini Jorilx QuickCRM connorshea LionelBino hieuhoanghd jsamelko %}}
 
 Please https://suitecrm.com/download[visit the official website] to find the appropriate upgrade.
 
@@ -1228,24 +1165,9 @@ via email security@suitecrm.com.
 
 Please https://suitecrm.com/download-latest-pre-release-suitecrm/[visit the official website] to find the pre-production appropriate upgrade.
 
-_Special thanks to the following members for their contributions and participation in this release!_
+_Special thanks to LEAP-nishit and the following members for their contributions and participation in this release!_
 
-* https://github.com/Abuelodelanada[Abuelodelanada]
-* https://github.com/adriangibanelbtactic[adriangibanelbtactic]
-* https://github.com/ApatheticCosmos[ApatheticCosmos]
-* https://github.com/ChangezKhan[ChangezKhan]
-* https://github.com/hieuhoanghd[hieuhoanghd]
-* https://github.com/horus68[horus68]
-* https://github.com/JanSiero[JanSiero]
-* https://github.com/Jorilx[Jorilx]
-* https://github.com/jsamelko[jsamelko]
-* https://github.com/lazka[lazka]
-* https://github.com/LEAP-nishit[LEAP-nishit]
-* https://github.com/likhobory[likhobory]
-* https://github.com/LionelBino[LionelBino]
-* https://github.com/Mausino[Mausino]
-* https://github.com/pribeiro42[pribeiro42]
-* https://github.com/urdhvatech[urdhvatech]
+{{% ghcontributors Abuelodelanada adriangibanelbtactic ApatheticCosmos ChangezKhan hieuhoanghd horus68 JanSiero Jorilx jsamelko lazka  likhobory LionelBino Mausino pribeiro42 urdhvatech %}}
 
 To report any security issues please follow our Security Process and send them directly to us
 via email security@suitecrm.com
@@ -1254,5 +1176,4 @@ Lastly a big thank you to the community for testing and confirming pull requests
 our 17-18th December 2018 Pull Request Party. This release is the result of the hard work and
 effort everyone put into the project!
 
-'''
 

--- a/content/admin/releases/7.11.x/_index.en.adoc
+++ b/content/admin/releases/7.11.x/_index.en.adoc
@@ -6,27 +6,26 @@ weight: 9880
 :toc:
 :toc-title:
 :toclevels: 1
-
-:experimental:
+:icons: font
 
 == 7.11.11
 
 _Released 10/02/2020_
 
-=== pass:[<i class="fa fa-files-o fa-1x"></i>] Assets
+=== icon:box-open[] Assets
 
 * https://github.com/salesagility/SuiteCRM/archive/v7.11.11.zip[*Source code* (zip)]
 * https://github.com/salesagility/SuiteCRM/archive/v7.11.11.tar.gz[*Source code* (tar.gz)]
 
 [discrete]
 
-==== pass:[<i class="fa fa-clipboard fa-1x"></i>] Administrators Note 1/2
+==== icon:clipboard[] Administrators Note 1/2
 You may notice when installing SuiteCRM a new panel which allows for the configuration of different collations and type-sets. This is part of our progression towards resolving issues with special characters and emojis. Currently available sets include utf8 and utf8mb4.
 
-==== pass:[<i class="fa fa-clipboard fa-1x"></i>] Administrators Note 2/2
+==== icon:clipboard[] Administrators Note 2/2
 Within this release, we have also resolved a few known issues with the upgrade process; however, they will unfortunately not take effect until the next upgrade cycle. Therefore it is vital that if you encounter any problems while installing that you review and follow the recommended process within the SuiteDocs upgrade debugging page which can be found https://community.suitecrm.com/t/debugging-steps-for-use-in-upgrade-version-prior-to-7-11-11-and-7-10-23/71273[here]
 
-==== pass:[<i class="fa fa-wrench fa-1x"></i>] Potential breaking change with package container-interop
+==== icon:wrench[] Potential breaking change with package container-interop
 If you maintain a CRM utilising container-interop for API extension, you should note that this release may require some small changes to routing as seen below:
 
 Instead of `Interop`
@@ -42,9 +41,9 @@ use Psr\Container\ContainerInterface;
 
 [discrete]
 
-===  pass:[<i class="fa fa-check fa-1x"></i>] Release Notes
+===  icon:check[] Release Notes
 
-==== pass:[<i class="fa fa-lock fa-1x"></i>] Security
+==== icon:lock[] Security
 
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8787[CVE-2020-8787^] - Bean ID validation strictness
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8783[CVE-2020-8783^] - Neutralization of potential vulnerability with use of Special Elements within SQL
@@ -54,7 +53,7 @@ use Psr\Container\ContainerInterface;
 
 [discrete]
 
-==== pass:[<i class="fa fa-star-o fa-1x"></i>] Enhancements
+==== icon:star[] Enhancements
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8100[8100^] - Issue: https://github.com/salesagility/SuiteCRM/issues/8099[8099^] - Add a way to hide/show columnChooser in ListViews
 * PR: https://github.com/salesagility/SuiteCRM/pull/7879[7879^] - Issue: https://github.com/salesagility/SuiteCRM/issues/7876[7876^] - Render phone fields as links
@@ -65,7 +64,7 @@ use Psr\Container\ContainerInterface;
 
 [discrete]
 
-==== pass:[<i class="fa fa-bug fa-1x"></i>] Bug Fixes
+==== icon:bug[] Bug Fixes
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8422[8422^] - Issue: https://github.com/salesagility/SuiteCRM/issues/8421[8421^] - Fix issue with validation on aos settings
 * PR: https://github.com/salesagility/SuiteCRM/pull/8395[8395^] - Issue: https://github.com/salesagility/SuiteCRM/issues/6000[6000^] - Notifications not working when using mssql
@@ -99,7 +98,7 @@ use Psr\Container\ContainerInterface;
 
 [discrete]
 
-==== pass:[<i class="fa fa-code-fork fa-1x"></i>] Development
+==== icon:code-branch[] Development
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8231[8231^] - Issue: https://github.com/salesagility/SuiteCRM/issues/7891[7891^] - Clean up include/ tests
 * PR: https://github.com/salesagility/SuiteCRM/pull/8218[8218^] - Issue: https://github.com/salesagility/SuiteCRM/issues/7744[7744^] - Remove deprecated functions from utils.php
@@ -132,7 +131,7 @@ use Psr\Container\ContainerInterface;
 * PR: https://github.com/salesagility/SuiteCRM/pull/8161[8161^] - Fix a PHP warning in Meeting.php
 [discrete]
 
-=== pass:[<i class="fa fa-heart fa-1x"></i>] Community
+=== icon:heart[] Community
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
@@ -156,18 +155,18 @@ To report any security issues please follow our Security Process and send them d
 
 _Released 11/11/2019_
 
-=== pass:[<i class="fa fa-files-o fa-1x"></i>] Assets
+=== icon:box-open[] Assets
 
 * https://github.com/salesagility/SuiteCRM/archive/v7.11.10.zip[*Source code* (zip)]
 * https://github.com/salesagility/SuiteCRM/archive/v7.11.10.tar.gz[*Source code* (tar.gz)]
 
-===  pass:[<i class="fa fa-check fa-1x"></i>] Release Notes
+===  icon:check[] Release Notes
 
-==== pass:[<i class="fa fa-lock fa-1x"></i>] Security
+==== icon:lock[] Security
 
 * CVE: Unassigned - SQL Injection
 
-==== pass:[<i class="fa fa-bug fa-1x"></i>] Bug Fixes
+==== icon:bug[] Bug Fixes
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8185[8185^] - Issue: https://github.com/salesagility/SuiteCRM/issues/7946[7946^] - Removed unnecessary JSSource files
 * PR: https://github.com/salesagility/SuiteCRM/pull/8187[8187^] - Issue: https://github.com/salesagility/SuiteCRM/issues/8183[8183^] - Non-group records show on list view if group only access
@@ -186,14 +185,14 @@ To report any security issues please follow our Security Process and send them d
 
 _Released 04/11/2019_
 
-=== pass:[<i class="fa fa-files-o fa-1x"></i>] Assets
+=== icon:box-open[] Assets
 
 * https://github.com/salesagility/SuiteCRM/archive/v7.11.9.zip[*Source code* (zip)]
 * https://github.com/salesagility/SuiteCRM/archive/v7.11.9.tar.gz[*Source code* (tar.gz)]
 
-===  pass:[<i class="fa fa-check fa-1x"></i>] Release Notes
+===  icon:check[] Release Notes
 
-==== pass:[<i class="fa fa-lock fa-1x"></i>] Security
+==== icon:lock[] Security
 
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18782[CVE-2019-18782^] - .htaccess Improvements
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18785[CVE-2019-18785^] - API Access Token and Credential fix
@@ -201,7 +200,7 @@ _Released 04/11/2019_
 
 [discrete]
 
-==== pass:[<i class="fa fa-star-o fa-1x"></i>] Enhancements
+==== icon:star[] Enhancements
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/7198[7198^] - Add Robo API commands
 * PR: https://github.com/salesagility/SuiteCRM/pull/5464[5464^] - Filter email templates on Events
@@ -216,7 +215,7 @@ _Released 04/11/2019_
 
 [discrete]
 
-==== pass:[<i class="fa fa-bug fa-1x"></i>] Bug Fixes
+==== icon:bug[] Bug Fixes
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8154[8154^] - Issue: https://github.com/salesagility/SuiteCRM/issues/8153[8153^] - SQL query in the ACLAction code
 * PR: https://github.com/salesagility/SuiteCRM/pull/8151[8151^] - Resolve issue with email templates
@@ -347,7 +346,7 @@ _Released 04/11/2019_
 
 [discrete]
 
-==== pass:[<i class="fa fa-code-fork fa-1x"></i>] Development
+==== icon:code-branch[] Development
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/8000[8000^] - More PHP 7.4 array accessor deprecations
 * PR: https://github.com/salesagility/SuiteCRM/pull/6750[6750^] - Issue: https://github.com/salesagility/SuiteCRM/issues/4754[4754^] - Remove PHP4 style constructors
@@ -356,7 +355,7 @@ _Released 04/11/2019_
 
 [discrete]
 
-=== pass:[<i class="fa fa-heart fa-1x"></i>] Community
+=== icon:heart[] Community
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
@@ -392,21 +391,21 @@ To report any security issues please follow our Security Process and send them d
 
 _Released 23/08/2019_
 
-=== pass:[<i class="fa fa-files-o fa-1x"></i>] Assets
+=== icon:box-open[] Assets
 
 * https://github.com/salesagility/SuiteCRM/archive/v7.11.8.zip[*Source code* (zip)]
 * https://github.com/salesagility/SuiteCRM/archive/v7.11.8.tar.gz[*Source code* (tar.gz)]
 
-===  pass:[<i class="fa fa-check fa-1x"></i>] Release Notes
+===  icon:check[] Release Notes
 
-==== pass:[<i class="fa fa-lock fa-1x"></i>] Security
+==== icon:lock[] Security
 
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14752[CVE-2019-14752^] - Reflected XSS
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18783[CVE-2019-18783^] - Unintended public exposure of files
 * CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14454[CVE-2019-14454^] - Employee module does not implement ACL
 [discrete]
 
-==== pass:[<i class="fa fa-star-o fa-1x"></i>] Enhancements
+==== icon:star[] Enhancements
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/7702[7702 ] - Issue: https://github.com/salesagility/SuiteCRM/issues/7696[7696 ] - Update README
 * PR: https://github.com/salesagility/SuiteCRM/pull/7698[7698 ] - Issue: https://github.com/salesagility/SuiteCRM/issues/7581[7581 ] - SuiteBot config.yml
@@ -433,7 +432,7 @@ Plugin files are still usable in the same way as before – at `./include/Smarty
 
 [discrete]
 
-==== pass:[<i class="fa fa-bug fa-1x"></i>] Bug Fixes
+==== icon:bug[] Bug Fixes
 
 * PR: https://github.com/salesagility/SuiteCRM/pull/7719[7719 ] - Fix/backwards compatibility
 * PR: https://github.com/salesagility/SuiteCRM/pull/7718[7718 ] - Issue: https://github.com/salesagility/SuiteCRM/issues/6982[6982 ] - New user password not being generated
@@ -448,7 +447,7 @@ Plugin files are still usable in the same way as before – at `./include/Smarty
 * PR: https://github.com/salesagility/SuiteCRM/pull/7610[7610 ] - Fixed error message css + email warning config option
 [discrete]
 
-=== pass:[<i class="fa fa-heart fa-1x"></i>] Community
+=== icon:heart[] Community
 
 _Special thanks to the following members for their contributions and participation in this release!_
 
@@ -470,27 +469,27 @@ To report any security issues please follow our Security Process and send them d
 
 _Released 31st July 2019_
 
-=== pass:[<i class="fa fa-files-o fa-1x"></i>] Assets
+=== icon:box-open[] Assets
 
 * https://github.com/salesagility/SuiteCRM/archive/v7.11.7.zip[*Source code* (zip)]
 * https://github.com/salesagility/SuiteCRM/archive/v7.11.7.tar.gz[*Source code* (tar.gz)]
 
-===  pass:[<i class="fa fa-check fa-1x"></i>] Release Notes
+===  icon:check[] Release Notes
 
-==== pass:[<i class="fa fa-lock fa-1x"></i>] Security
+==== icon:lock[] Security
 
 [discrete]
 
 * https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-13335[#CVE-2019-13335 ] - *Security Issue* - Fixed SSRF
 * *Security Issue* - Fixed privilege escalation
 
-==== pass:[<i class="fa fa-star-o fa-1x"></i>] Enhancements 
+==== icon:star[] Enhancements 
 
 * https://github.com/salesagility/SuiteCRM/pull/7374[#7374 ] Robo test-running commands
 * https://github.com/salesagility/SuiteCRM/pull/7474[#7474 ] SecuritySuite 3.1.16
 * https://github.com/salesagility/SuiteCRM/pull/7503[#7503 ] Scheduled Reports: Enable security groups support and add the subpanel
 
-==== pass:[<i class="fa fa-bug fa-1x"></i>] Bug Fixes
+==== icon:bug[] Bug Fixes
 
 * https://github.com/salesagility/SuiteCRM/issues/3756[#3756 ] Fixed #3756 - Calendar pop-ups now auto close after 500ms
 * https://github.com/salesagility/SuiteCRM/pull/6850[#6850 ] SAML2: Use php-saml from composer
@@ -546,7 +545,7 @@ _Released 31st July 2019_
 * https://github.com/salesagility/SuiteCRM/issues/6996[#6996 ] Escaped strings issue, breaks "My favorites" filters and perhaps other things
 * https://github.com/salesagility/SuiteCRM/pull/7639[#7639 ] Fixed DB failure with activities subpanel
 
-=== pass:[<i class="fa fa-heart fa-1x"></i>] Community
+=== icon:heart[] Community
 
 _Special thanks to all members for their contributions and participation in this release!_
 
@@ -1256,3 +1255,4 @@ our 17-18th December 2018 Pull Request Party. This release is the result of the 
 effort everyone put into the project!
 
 '''
+

--- a/layouts/shortcodes/ghcontributors.html
+++ b/layouts/shortcodes/ghcontributors.html
@@ -1,3 +1,4 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
 {{/*
 --------------------
 Shortcode usage:
@@ -23,7 +24,7 @@ Shortcode usage:
 {{ range .Params }}
   {{ $git_user := . }}
   {{ $u := getJSON "https://api.github.com/users/" $git_user }}
-<div>
+  <div>
     <div style="float:top;">
       <a href="{{$u.avatar_url}}" data-featherlight="image">
       <img src="{{$u.avatar_url}}" class="inline" style="width: 50px;height: 50px;margin-bottom:.25em; vertical-align:middle;">
@@ -33,3 +34,4 @@ Shortcode usage:
   </div>
 {{ end }}
 </div>
+<div style="clear: both;"></div>


### PR DESCRIPTION
- fixes icons
- shortens GitHub contributors lists tremendously
- a few other removals of unnecessary `pass:`