### PR TITLE
Update JSON-API.adoc (Generate OAuth2 Encryption Key command line)

### DIFF
--- a/content/developer/api/Developer-setup-guide/JSON-API.adoc
+++ b/content/developer/api/Developer-setup-guide/JSON-API.adoc
@@ -46,7 +46,7 @@ OAuth2’s AuthorizationServer needs to set an encryption key for security reaso
 This key has been gererated during the SuiteCRM installation and stored in the config.php under "oauth2_encryption_key".
 If you would like to change its value you may generate a new one by running
 [source,php]
-echo base64_encode(random_bytes(32)).PHP_EOL;
+php -r 'echo base64_encode(random_bytes(32)), PHP_EOL;'
 
 and then storing the output in the config.php.
 


### PR DESCRIPTION
Previous example commands to generate OAuth2 keys are complete and can be typed directly in a terminal as written. The generate a new "OAUTH2 encryption key" command line requires "php -r" at the beginning and a novice would probably not know to do this without further research or experience.

The proposed change matches the example found at: https://oauth2.thephpleague.com/v5-security-improvements/