### PR TITLE
Create add-campaign-support-custom-module.adoc

### DIFF
--- a/content/blog/add-campaign-support-custom-module.adoc
+++ b/content/blog/add-campaign-support-custom-module.adoc
@@ -1,0 +1,160 @@
+---
+title: How to Add Campaign/Target List Support for a Custom Module (contacts)
+weight: 50
+Author: Paul Stevens
+Date: 20-06-2020
+---
+
+---
+
+
+*The Problem*
+
+Just creating a relationship between your custom module contacts and Target Lists does not allow you to use the campaign feature like you're used to with Leads, Targets and Contacts.  In order to add campaign functionality to a custom contact module, you must do the following:
+
+
+*Before You Start*
+-------
+* Create One to Many relationship between your custom module and “Activities” module.
+* Create a One to Many relationship between your custom module and “Emails” module.
+-------
+
+
+TIP:  In the code below replace{module} with the name of your custom module. When you navigate to custom/modules/{module}
+the module name will be the name of the folder.
+------
+------
+Step 1:
+------
+Add a custom list view for your custom module (custom/modules/{MODULE}/views/view.list.php)
+
+TIP:  You may have to create the files and directories.
+[source,php]
+----
+<?php
+require_once('include/MVC/View/views/view.list.php');
+class {MODULE}ViewList extends ViewList
+{
+ 	public function preDisplay()
+ 	{
+ 		parent::preDisplay();
+ 		$this->lv->targetList = true;
+ 	}
+}
+?>
+----
+
+Step 2:
+------
+Create extended vardef for prospect list → custom module relationship (custom/extension/modules/{MODULE}Ext/Vardefs/prospect_list_{MODULE}.php
+----
+<?php
+$dictionary["{MODULE}"]["relationships"]["prospect_list_{MODULE}"] = array (
+	'lhs_module' => 'ProspectLists',
+	'lhs_table' => 'prospect_lists',
+	'lhs_key' => 'id',
+	'rhs_module' => '{MODULE}',
+	'rhs_table' => '{MODULE_TABLE}',
+	'rhs_key' => 'id',
+	'relationship_type' => 'many-to-many',
+	'join_table' => 'prospect_lists_prospects',
+	'join_key_lhs' => 'prospect_list_id',
+	'join_key_rhs' => 'related_id',
+	'relationship_role_column' => 'related_type',
+	'relationship_role_column_value' => '{MODULE}'
+);
+
+
+$dictionary["{MODULE}"]["fields"]["prospect_lists"] = array (
+	'name' => 'prospect_lists',
+	'type' => 'link',
+	'relationship' => 'prospect_list_{MODULE}',
+	'source' => 'non-db'
+);
+?>
+----
+Step 3:
+~~~~~~~
+Create a subpanel definition to show the prospect list subpanel on your custom module (custom/extension/modules/{MODULE}/Ext/Layoutdefs/ProspectListSubpanel.php)
+----
+<?php
+$layout_defs["{MODULE}"]["subpanel_setup"]["prospect_lists"] = array (
+		'order' => 10,
+			'sort_by' => 'name',
+			'sort_order' => 'asc',
+			'module' => 'ProspectLists',
+			'subpanel_name' => 'default',
+			'get_subpanel_data' => 'prospect_lists',
+			'title_key' => 'LBL_PROSPECT_LISTS_SUBPANEL_TITLE',
+			'top_buttons' => array(
+			    array('widget_class' => 'SubPanelTopButtonQuickCreate'),
+				array('widget_class'=>'SubPanelTopSelectButton','mode'=>'MultiSelect'),
+			),
+);
+?>
+----
+
+Step 4:
+~~~~~~~
+Create a subpanel def for your custom module on the prospect list detailview(custom/extension/modules/ProspectLists/Ext/Layoutdefs/prospect_lists_{MODULE}.php
+----
+<?php
+$layout_defs["ProspectLists"]["subpanel_setup"]["{MODULE}"] = array (   //module name in lowercase
+	'order' => 10,
+	'sort_by' => 'name',
+	'sort_order' => 'asc',
+	'module' => '{MODULE}',
+	'subpanel_name' => 'ForProspectLists',
+	'get_subpanel_data' => '{MODULE}',//lowercase!!
+	'title_key' => 'LBL_{MODULE}_SUBPANEL_TITLE',
+	'top_buttons' => array(
+		array('widget_class' => 'SubPanelTopButtonQuickCreate'),
+		array('widget_class'=>'SubPanelTopSelectButton','mode'=>'MultiSelect'),
+	),
+);
+?>
+----
+
+Step 5:
+~~~~~~~
+Create a vardef relationship field extension in custom/extensions/modules/ProspectLists/Ext/Vardefs/custom.php
+----
+<?php
+$dictionary['ProspectList']['fields']['{MODULE}'] =array (  //module name in lowercase
+  			'name' => '{MODULE}',//lowercase!!
+    		'type' => 'link',
+    		'relationship' => 'prospect_list_{MODULE}',
+    		'source'=>'non-db',
+  		);
+  ?>
+----
+
+Step 6:
+~~~~~~~
+Create subpanel metadata – Copy modules/{MODULE}/metadata/subpanels/default.php then rename and 
+copy to: custom/modules/{MODULE}/metadata/subpanels/ForProspectLists.php
+
+Step 7:
+~~~~~~~
+Edit modules/EmailMan/EmailMan.php around line 665 add:
+----
+$this->ref_email->load_relationship('{MODULE_EMAILS_REL_NAME');
+----
+You must have a relationship between your custom module and the emails module. You can find the name of the of relationship by looking in custom/Extension/modules/Emails/Ext/Vardefs/{MODULE}_activities_emails.php at the “name” property.
+
+Around Line 689 Add:
+
+----
+case '{MODULE}':
+		$rel_name="{MODULE_EMAILS_REL_NAME}";
+		break;
+----
+
+TIP:  Don't Forget to do a Repair and Rebuild
+------
+References
+------
+http://web.archive.org/web/20140825230331/http:/sugaruk.co.uk/blog/how-add-campaigntarget-list-support-custom-person-module-sugarcrm[http://web.archive.org/web/20140825230331/http:/sugaruk.co.uk/blog/how-add-campaigntarget-list-support-custom-person-module-sugarcrm]
+
+
+CAUTION:  This currently works, to be able to add custom contact module person to a target list.  It also allows that person contained in the target list to be added to a campaign.  The campaign is able to be processed and the email receipients are added to the outbound email queue.  At the time of this writing the emails do not get sent from the queue.  Looking for some collaboration to resolve this one last issue.


### PR DESCRIPTION
Just creating a relationship between your custom module contacts and Target Lists does not allow you to use the campaign feature like you’re used to with Leads, Targets and Contacts. In order to add campaign functionality to a custom contact module, you must follow the steps in this blog to add the functionality.