### PR TITLE
Fix broken link in Contributor Agreement

### DIFF
--- a/content/community/contributing-code/Contributor Agreement.adoc
+++ b/content/community/contributing-code/Contributor Agreement.adoc
@@ -6,7 +6,7 @@ Title: Contributor Agreement
 == Where can I find the Contributor Agreement?
 
 You can find the contributor agreement
-https://www.clahub.com/agreements/salesagility/SuiteCRM[here].
+https://cla.suitecrm.com/salesagility/SuiteCRM[here].
 
 == What is the Contributor Agreement?
 


### PR DESCRIPTION
CLAHub is down and the service is no longer available as it was deleted.

Fixes: #466