### PR TITLE
Add documentation for module meta data in V8 API

### DIFF
--- a/content/developer/api/Developer-setup-guide/JSON-API.adoc
+++ b/content/developer/api/Developer-setup-guide/JSON-API.adoc
@@ -260,6 +260,16 @@ Result:
 [source,php]
 POST {{suiteCRM.url}}/V8/logout
 
+=== Modules
+
+[source,php]
+GET {{suiteCRM.url}}/V8/meta/modules
+
+=== Module Fields
+
+[source,php]
+GET {{suiteCRM.url}}/V8/meta/fields/{moduleName}
+
 === Get a module by ID
 
 [source,php]


### PR DESCRIPTION
Pull Request https://github.com/salesagility/SuiteCRM/pull/7277 adds the ability to retrieve modules and fields for a module. It doesn't appear this was ever documented.