### PR TITLE
Update developer install guide

### DIFF
--- a/content/8.x/developer/development-install-guide.adoc
+++ b/content/8.x/developer/development-install-guide.adoc
@@ -3,7 +3,9 @@ title: "Developer Install Guide"
 weight: 30
 ---
 
-= Developer Install Guide
+{{% notice info %}}
+The following documentation is for SuiteCRM Version 8+; to see documentation for Version 7, click link:/developer/introduction[here].
+{{% /notice %}}
 
 == Quick Start Guide
 For System Requirements see the compatibility matrix link:/8.x/admin/compatibility-matrix[here]
@@ -11,6 +13,12 @@ For System Requirements see the compatibility matrix link:/8.x/admin/compatibili
 === Pre-Installation
 
 . Setup php, mysql and apache
+
+{{% notice note %}}
+Please make sure that your `apache` has `mod_rewrite` enabled and that it is properly configured to allow for re-writes.
+All SuiteCRM-Core api calls depend on this (calls to `api/graphql`) if re-rewrites are not allowed you will get a `404` when calling the api.
+{{% /notice %}}
+
 . Install composer
 . Install node and npm
 . Install angular cli
@@ -20,8 +28,8 @@ For System Requirements see the compatibility matrix link:/8.x/admin/compatibili
 
 . Run `composer install` or for production `composer install --no-dev` in the root directory
 . Run `yarn install` in the root directory
-. Run `composer install` or for production `composer install --no-dev` in legacy directory
-. Run legacy theme compile in the legacy directory
+. Run `composer install` or for production `composer install --no-dev` in legacy directory (`/public/legacy`)
+. Run legacy theme compile in the legacy directory (`/public/legacy`)
 +
 [source,bash]
 ----
@@ -39,14 +47,17 @@ find . \! -user www-data -exec chown www-data:www-data {} \;
 
 chmod +x bin/console
 ----
-. Go back to suite8 root folder
-. Run `./bin/console suitecrm:app:install` (or pass on the options, e.g. -u <admin_username>)
 
 . Run `yarn run build:common` or `yarn run build-dev:common` (for dev environment)
 . Run `yarn run build:core` or `yarn run build-dev:core` (for dev environment)
-
 . Run `yarn run build:shell` or `yarn run build-dev:shell` (for dev environment)
+
 . Run `composer dumpautoload`
+
+. Go back to suite8 root folder
+. Run `./bin/console suitecrm:app:install` (or pass on the options, e.g. -u <admin_username>)
+    - **Note:** before running the command make sure to create the database (the command will create the needed tables)
+
 . Re-set permissions
 
 +
@@ -71,7 +82,7 @@ From the suite 8 root folder
 
 . Run `composer install`
 +
-[NOTE]
+
 Depending on the changes you are working on you may also need to run the following
 
 . Run `composer dumpautoload`
@@ -83,7 +94,11 @@ From the suite 8 root folder
 
 * Run `yarn run build-dev:common`
 * Run `yarn run build-dev:core`
-* Run `yarn run build:shell`
+* Run `yarn run build-dev:shell`
+
+{{% notice note %}}
+When building common, core and shell you need to build all in prod mode or all in non-prod mode.
+{{% /notice %}}
 
 ==== Run frontend unit tests
 


### PR DESCRIPTION
- Replace prod mode shell build command reference with dev mode. All frontend builds need to be done in same mode
- Move suitecrm:app:install call to end of the install process