### PR TITLE
Update Set up Elasticsearch.adoc

### DIFF
--- a/content/admin/administration-panel/search/elasticsearch/Set up Elasticsearch.adoc
+++ b/content/admin/administration-panel/search/elasticsearch/Set up Elasticsearch.adoc
@@ -10,7 +10,7 @@ This enhancement is only available in SuiteCRM from version 7.11 onwards.
 :toc:
 
 {{% notice note %}}
-SuiteCRM requires Elasticsearch 5.6.
+SuiteCRM 7.11 requires Elasticsearch 5.6. SuiteCRM 7.12 requires Elasticsearch 7.
 {{% /notice %}}
 
 Elasticsearch requires Java 8 to run, supporting only `Oracle Java` and `OpenJDK`.


### PR DESCRIPTION
SuiteCRM 7.12 requires Elasticsearch 7 and fails with version 5.6. This was deployed here https://github.com/salesagility/SuiteCRM/pull/9171

Related forum message... https://community.suitecrm.com/t/elasticsearch-throw-type-is-missing-and-no-index-is-populated/83511/4