### PR TITLE
updating to include robo workaround...

### DIFF
--- a/content/developer/automatedtasks/_index.en.adoc
+++ b/content/developer/automatedtasks/_index.en.adoc
@@ -11,7 +11,7 @@ SuiteCRM utilises https://robo.li[Robo tasks] to provide automation for common t
 
 {{% notice info %}}
 
-Robo <3.0.7 falls to call autoload.php relative to the vendor/bin. This may cause errors when trying to run any of SuiteCRM's robo commands. Recommdation is to update the instance's robo composer libraries to 3.0.7+. Alternatively replace the following commands pathname reference of `./vendor/bin/robo` to `./vendor/consolidation/robo/robo`
+Robo <3.0.7 fails to call autoload.php relative to the vendor/bin. This may cause errors when trying to run any of SuiteCRM's robo commands. Recommdation is to update the instance's robo composer libraries to 3.0.7+. Alternatively replace the following commands pathname reference of `./vendor/bin/robo` to `./vendor/consolidation/robo/robo`
 
 {{% /notice %}}
 

--- a/content/developer/automatedtasks/_index.en.adoc
+++ b/content/developer/automatedtasks/_index.en.adoc
@@ -9,6 +9,12 @@ weight: 17
 
 SuiteCRM utilises https://robo.li[Robo tasks] to provide automation for common tasks.
 
+{{% notice info %}}
+
+Robo <3.0.7 falls to call autoload.php relative to the vendor/bin. This may cause errors when trying to run any of SuiteCRM's robo commands. Recommdation is to update the instance's robo composer libraries to 3.0.7+. Alternatively replace the following commands pathname reference of `./vendor/bin/robo` to `./vendor/consolidation/robo/robo`
+
+{{% /notice %}}
+
 === Listing the available automated tasks in Robo
 
 ==== Linux:


### PR DESCRIPTION
This is in reference to this issue:
https://github.com/salesagility/SuiteCRM/issues/9224

Where the upstream should now be rectified by this commit https://github.com/consolidation/robo/pull/1056/files.
We shouldn't need to update the pathnames used in bash commands but its best to state that it would be dependent on the instance's robo version. 

This PR also superseeds the following PRs
https://github.com/salesagility/SuiteDocs/pull/543
https://github.com/salesagility/SuiteDocs/pull/553


Including a centralised point for composer incorrect path reference