### PR TITLE
changed website variable

### DIFF
--- a/content/developer/api/Developer-setup-guide/Getting Available Resources.adoc
+++ b/content/developer/api/Developer-setup-guide/Getting Available Resources.adoc
@@ -12,12 +12,12 @@ retrieve the https://swagger.io/specification/[swagger documentation] via 2 rout
 On the server the documentation is located at
 
 [source]
-pathtoserver/Api/docs/swagger/swagger.json
+{{suitecrm.url}}/Api/docs/swagger/swagger.json
 
 You can also retrieve the documentation via an API call:
 
 [source]
-GET pathtoserver/Api/V8/meta/swagger.json
+GET {{suitecrm.url}}/Api/V8/meta/swagger.json
 
 The swagger documentation is a JSON file that includes information on what the default API is capable of and how to structure an API call.
 
@@ -83,7 +83,7 @@ This will tell you everything you need to know about how to structure the API Re
 
 === path
 
-The path or URI of this api request i.e. "pathtoserver/module/{moduleName}/{id}"
+The path or URI of this api request i.e. "{{suitecrm.url}}/module/{moduleName}/{id}"
 
 === get
 


### PR DESCRIPTION
the documentation [here](https://docs.suitecrm.com/developer/api/developer-setup-guide/json-api/) uses suitecrm.url to point to the server while this documentation site uses pathtoserver changed this to make it more uniform across the docs