### PR TITLE
removed dots from vhost configurations

### DIFF
--- a/content/8.x/admin/installation-guide/webserver-setup-guide.adoc
+++ b/content/8.x/admin/installation-guide/webserver-setup-guide.adoc
@@ -77,12 +77,11 @@ It is highly recommended that you update the webroot or configure vhost to point
 {{% /notice %}}
 
 
-On your vhost configuration you need something like:
+Update your vhost configuration to add the following:
 
 [source,xml]
 ----
 <VirtualHost *:80>
-    ...
 
     DocumentRoot /<path-to-suite>/public
     <Directory /<path-to-suite>/public>


### PR DESCRIPTION
I think just leaving them in there doesnt make it clear that you should add it to the existing one therefore the wording should be changed