### PR TITLE
Fix https://github.com/salesagility/SuiteCRM-Core/issues/419 and 

### DIFF
--- a/content/8.x/admin/installation-guide/webserver-setup-guide.adoc
+++ b/content/8.x/admin/installation-guide/webserver-setup-guide.adoc
@@ -59,6 +59,7 @@ Install on your server the required php modules:
 * zip
 * imap (optional)
 * ldap (optional)
+* auth-sasl (required to login to some email accounts)
 
 === Helpfull Resources
 


### PR DESCRIPTION
Fixes https://github.com/salesagility/SuiteCRM/issues/10256

This documentation fix tells admins what PHP module to install to allow Suite to connect to Inbound email accounts (and other cloud accounts) that require `DIGEST-MD5` secure login protocol.