### PR TITLE
Fix docs omit the php module requirement `auth-sasl`

### DIFF
--- a/content/admin/installation-guide/Downloading & Installing.adoc
+++ b/content/admin/installation-guide/Downloading & Installing.adoc
@@ -87,6 +87,7 @@ permissions on your SuiteCRM instance, visit our support forums.
 * cURL Module
 * Upload File Size
 * Sprite Support
+* auth-sasl (for connecting to Inbound email inboxes)
 
 ==== Notes about PHP configuration
 


### PR DESCRIPTION
Fixes https://github.com/salesagility/SuiteCRM/issues/10256 and...  Fixes https://github.com/salesagility/SuiteCRM-Core/issues/419

Both the same bug for v7 and v8, Suite fails to login to a variety of popular self-hosted and online Inbound email inboxes.

Turns out, Suite requires this php module `auth-sasl` to connect successfully to many Linux mail servers (Dovecot, Cyrus, etc) and popular online email inbox service providers.  This module provides support for several additional standard login protocols, not part of the basic PHP.